### PR TITLE
Introduce additional casing strategies.

### DIFF
--- a/options.go
+++ b/options.go
@@ -9,6 +9,9 @@ const (
 	// SnakeCaseStrategy is the snake case strategy.
 	SnakeCaseStrategy CaseStrategy = "snake"
 
+	// ScreamingSnakeCaseStrategy is the screaming (uppercase) snake case strategy.
+	ScreamingSnakeCaseStrategy CaseStrategy = "screaming_snake"
+
 	// CamelCaseStrategy is the camel case strategy.
 	CamelCaseStrategy CaseStrategy = "camel"
 
@@ -90,6 +93,11 @@ func (c *ReflectConfiguration) SnakeCaseTableName() bool {
 	return c.HasTableNameStrategy() && *c.TableNameStrategy == SnakeCaseStrategy
 }
 
+// ScreamingSnakeCaseTableName indicates if the table name strategy is screaming snake case.
+func (c *ReflectConfiguration) ScreamingSnakeCaseTableName() bool {
+	return c.HasTableNameStrategy() && *c.TableNameStrategy == ScreamingSnakeCaseStrategy
+}
+
 // CamelCaseTableName indicates if the table name strategy is camel case.
 func (c *ReflectConfiguration) CamelCaseTableName() bool {
 	return c.HasTableNameStrategy() && *c.TableNameStrategy == CamelCaseStrategy
@@ -100,9 +108,24 @@ func (c *ReflectConfiguration) SnakeCaseColumnName() bool {
 	return c.HasColumnNameStrategy() && *c.ColumnNameStrategy == SnakeCaseStrategy
 }
 
+// ScreamingSnakeCaseColumnName indicates if the column name strategy is scream snake case.
+func (c *ReflectConfiguration) ScreamingSnakeCaseColumnName() bool {
+	return c.HasColumnNameStrategy() && *c.ColumnNameStrategy == ScreamingSnakeCaseStrategy
+}
+
 // CamelCaseColumnName indicates if the column name strategy is camel case.
 func (c *ReflectConfiguration) CamelCaseColumnName() bool {
 	return c.HasColumnNameStrategy() && *c.ColumnNameStrategy == CamelCaseStrategy
+}
+
+// UppercaseColumnName indicates if the column name strategy is uppercase.
+func (c *ReflectConfiguration) UppercaseColumnName() bool {
+	return c.HasColumnNameStrategy() && *c.ColumnNameStrategy == UpperCaseStrategy
+}
+
+// LowercaseColumnName indicates if the column name strategy is uppercase.
+func (c *ReflectConfiguration) LowercaseColumnName() bool {
+	return c.HasColumnNameStrategy() && *c.ColumnNameStrategy == LowerCaseStrategy
 }
 
 // LowercaseTableAlias indicates if the table alias strategy is lowercase.

--- a/reflect.go
+++ b/reflect.go
@@ -48,6 +48,11 @@ func Reflect(obj interface{}, options ...ReflectOption) (Table, error) {
 			tableName = &tName
 		}
 
+		if configuration.ScreamingSnakeCaseTableName() {
+			tName := strings.ToUpper(strcase.ToSnake(t.Name()))
+			tableName = &tName
+		}
+
 		if configuration.CamelCaseTableName() {
 			tName := strcase.ToCamel(t.Name())
 			tableName = &tName
@@ -133,8 +138,21 @@ func fields(t reflect.Type, v reflect.Value, c ReflectConfiguration) []Column {
 			if c.SnakeCaseColumnName() {
 				columnName = strcase.ToSnake(columnName)
 			}
+
+			if c.ScreamingSnakeCaseColumnName() {
+				columnName = strings.ToUpper(strcase.ToSnake(columnName))
+			}
+
 			if c.CamelCaseColumnName() {
 				columnName = strcase.ToCamel(columnName)
+			}
+
+			if c.UppercaseColumnName() {
+				columnName = strings.ToUpper(columnName)
+			}
+
+			if c.LowercaseColumnName() {
+				columnName = strings.ToLower(columnName)
 			}
 		}
 
@@ -187,8 +205,21 @@ func methods(t reflect.Type, c ReflectConfiguration) []Column {
 			if c.SnakeCaseColumnName() {
 				columnName = strcase.ToSnake(columnName)
 			}
+
+			if c.ScreamingSnakeCaseColumnName() {
+				columnName = strings.ToUpper(strcase.ToSnake(columnName))
+			}
+
 			if c.CamelCaseColumnName() {
 				columnName = strcase.ToCamel(columnName)
+			}
+
+			if c.UppercaseColumnName() {
+				columnName = strings.ToUpper(columnName)
+			}
+
+			if c.LowercaseColumnName() {
+				columnName = strings.ToLower(columnName)
 			}
 		}
 

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -355,6 +355,117 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 			},
 		},
 		{
+			name: "WithInferredColumnNames_ScreamingSnakeCase_SetsToScreamingSnakeCase",
+			obj:  s.obj,
+			options: []morph.ReflectOption{
+				morph.WithInferredColumnNames(morph.ScreamingSnakeCaseStrategy),
+				morph.WithPrimaryKeyColumn("ID"),
+			},
+			expected: func() morph.Table {
+				t := morph.Table{}
+				t.SetType(s.obj)
+				t.SetName("test_models")
+				t.SetAlias("T")
+
+				columns := []morph.Column{}
+
+				var idColumn morph.Column
+				idColumn.SetName("ID")
+				idColumn.SetField("ID")
+				idColumn.SetPrimaryKey(true)
+				idColumn.SetStrategy(morph.FieldStrategyStructField)
+				idColumn.SetFieldType("int")
+
+				var nameColumn morph.Column
+				nameColumn.SetName("NAME")
+				nameColumn.SetField("Name")
+				nameColumn.SetStrategy(morph.FieldStrategyStructField)
+				nameColumn.SetFieldType("*string")
+
+				var createdAtColumn morph.Column
+				createdAtColumn.SetName("CREATED_AT")
+				createdAtColumn.SetField("CreatedAt")
+				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
+				createdAtColumn.SetFieldType("time.Time")
+
+				t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...)
+				return t
+			},
+		},
+		{
+			name: "WithInferredColumnNames_Uppercase_SetsToUppercase",
+			obj:  s.obj,
+			options: []morph.ReflectOption{
+				morph.WithInferredColumnNames(morph.UpperCaseStrategy),
+				morph.WithPrimaryKeyColumn("ID"),
+			},
+			expected: func() morph.Table {
+				t := morph.Table{}
+				t.SetType(s.obj)
+				t.SetName("test_models")
+				t.SetAlias("T")
+
+				columns := []morph.Column{}
+
+				var idColumn morph.Column
+				idColumn.SetName("ID")
+				idColumn.SetField("ID")
+				idColumn.SetPrimaryKey(true)
+				idColumn.SetStrategy(morph.FieldStrategyStructField)
+				idColumn.SetFieldType("int")
+
+				var nameColumn morph.Column
+				nameColumn.SetName("NAME")
+				nameColumn.SetField("Name")
+				nameColumn.SetStrategy(morph.FieldStrategyStructField)
+				nameColumn.SetFieldType("*string")
+
+				var createdAtColumn morph.Column
+				createdAtColumn.SetName("CREATEDAT")
+				createdAtColumn.SetField("CreatedAt")
+				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
+				createdAtColumn.SetFieldType("time.Time")
+
+				t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...)
+				return t
+			},
+		},
+		{
+			name:    "WithInferredColumnNames_Lowercase_SetsToLowercase",
+			obj:     s.obj,
+			options: []morph.ReflectOption{morph.WithInferredColumnNames(morph.LowerCaseStrategy)},
+			expected: func() morph.Table {
+				t := morph.Table{}
+				t.SetType(s.obj)
+				t.SetName("test_models")
+				t.SetAlias("T")
+
+				columns := []morph.Column{}
+
+				var idColumn morph.Column
+				idColumn.SetName("id")
+				idColumn.SetField("ID")
+				idColumn.SetPrimaryKey(true)
+				idColumn.SetStrategy(morph.FieldStrategyStructField)
+				idColumn.SetFieldType("int")
+
+				var nameColumn morph.Column
+				nameColumn.SetName("name")
+				nameColumn.SetField("Name")
+				nameColumn.SetStrategy(morph.FieldStrategyStructField)
+				nameColumn.SetFieldType("*string")
+
+				var createdAtColumn morph.Column
+				createdAtColumn.SetName("createdat")
+				createdAtColumn.SetField("CreatedAt")
+				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
+				createdAtColumn.SetFieldType("time.Time")
+
+				t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...)
+				return t
+			},
+		},
+		{
 			name:    "WithInferredColumnNames_Camelcase_SetsToCamelcase",
 			obj:     s.obj,
 			options: []morph.ReflectOption{morph.WithInferredColumnNames(morph.CamelCaseStrategy)},
@@ -920,6 +1031,117 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 
 				var createdAtColumn morph.Column
 				createdAtColumn.SetName("created_at")
+				createdAtColumn.SetField("CreatedAt")
+				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
+				createdAtColumn.SetFieldType("time.Time")
+
+				t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...)
+				return t
+			},
+		},
+		{
+			name: "WithInferredColumnNames_ScreamingSnakeCase_SetsToScreamingSnakeCase",
+			obj:  s.objPtr,
+			options: []morph.ReflectOption{
+				morph.WithInferredColumnNames(morph.ScreamingSnakeCaseStrategy),
+				morph.WithPrimaryKeyColumn("ID"),
+			},
+			expected: func() morph.Table {
+				t := morph.Table{}
+				t.SetType(s.objPtr)
+				t.SetName("test_models")
+				t.SetAlias("T")
+
+				columns := []morph.Column{}
+
+				var idColumn morph.Column
+				idColumn.SetName("ID")
+				idColumn.SetField("ID")
+				idColumn.SetPrimaryKey(true)
+				idColumn.SetStrategy(morph.FieldStrategyStructField)
+				idColumn.SetFieldType("int")
+
+				var nameColumn morph.Column
+				nameColumn.SetName("NAME")
+				nameColumn.SetField("Name")
+				nameColumn.SetStrategy(morph.FieldStrategyStructField)
+				nameColumn.SetFieldType("*string")
+
+				var createdAtColumn morph.Column
+				createdAtColumn.SetName("CREATED_AT")
+				createdAtColumn.SetField("CreatedAt")
+				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
+				createdAtColumn.SetFieldType("time.Time")
+
+				t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...)
+				return t
+			},
+		},
+		{
+			name: "WithInferredColumnNames_Uppercase_SetsToUppercase",
+			obj:  s.objPtr,
+			options: []morph.ReflectOption{
+				morph.WithInferredColumnNames(morph.UpperCaseStrategy),
+				morph.WithPrimaryKeyColumn("ID"),
+			},
+			expected: func() morph.Table {
+				t := morph.Table{}
+				t.SetType(s.objPtr)
+				t.SetName("test_models")
+				t.SetAlias("T")
+
+				columns := []morph.Column{}
+
+				var idColumn morph.Column
+				idColumn.SetName("ID")
+				idColumn.SetField("ID")
+				idColumn.SetPrimaryKey(true)
+				idColumn.SetStrategy(morph.FieldStrategyStructField)
+				idColumn.SetFieldType("int")
+
+				var nameColumn morph.Column
+				nameColumn.SetName("NAME")
+				nameColumn.SetField("Name")
+				nameColumn.SetStrategy(morph.FieldStrategyStructField)
+				nameColumn.SetFieldType("*string")
+
+				var createdAtColumn morph.Column
+				createdAtColumn.SetName("CREATEDAT")
+				createdAtColumn.SetField("CreatedAt")
+				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
+				createdAtColumn.SetFieldType("time.Time")
+
+				t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...)
+				return t
+			},
+		},
+		{
+			name:    "WithInferredColumnNames_LowerCase_SetsToLowerCase",
+			obj:     s.objPtr,
+			options: []morph.ReflectOption{morph.WithInferredColumnNames(morph.LowerCaseStrategy)},
+			expected: func() morph.Table {
+				t := morph.Table{}
+				t.SetType(s.objPtr)
+				t.SetName("test_models")
+				t.SetAlias("T")
+
+				columns := []morph.Column{}
+
+				var idColumn morph.Column
+				idColumn.SetName("id")
+				idColumn.SetField("ID")
+				idColumn.SetPrimaryKey(true)
+				idColumn.SetStrategy(morph.FieldStrategyStructField)
+				idColumn.SetFieldType("int")
+
+				var nameColumn morph.Column
+				nameColumn.SetName("name")
+				nameColumn.SetField("Name")
+				nameColumn.SetStrategy(morph.FieldStrategyStructField)
+				nameColumn.SetFieldType("*string")
+
+				var createdAtColumn morph.Column
+				createdAtColumn.SetName("createdat")
 				createdAtColumn.SetField("CreatedAt")
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")


### PR DESCRIPTION
**Description**

These changes introduce support for the following column casing strategies:

- screaming snake case (`EXAMPLE_COLUMN_NAME`)
- uppercase (`EXAMPLECOLUMNNAME`)
- lowercase (`examplecolumnname`)

It additionally supports screaming snake case for table names.

> NOTE: it's important to use the same specified casing when using the `WithPrimaryKeyColumn` or `WithPrimaryKeyColumns` options.

**Rationale**

While less common, these casing strategies for columns and tables do occur.

**Suggested Version**

`v1.2.0`

**Example Usage**

```go
obj = ...

// uppercase column names.
options := []morph.ReflectOptions{
  morph.WithInferredColumnNames(morph.UpperCaseStrategy),
  moprh.WithPrimaryKeyColumn("ID"),
}
table, err := morph.Reflect(obj, options...)
if err != nil {
  panic(err)
}

// lowercase column names.
options := []morph.ReflectOptions{
  morph.WithInferredColumnNames(morph.LowerCaseStrategy),
  moprh.WithPrimaryKeyColumn("id"),
}
table, err := morph.Reflect(obj, options...)
if err != nil {
  panic(err)
}

// screaming snake case column names.
options := []morph.ReflectOptions{
  morph.WithInferredColumnNames(morph.ScreamingSnakeCaseStrategy),
  moprh.WithPrimaryKeyColumn("ID"),
}
table, err := morph.Reflect(obj, options...)
if err != nil {
  panic(err)
}
```
