### PR TITLE
Expand reflection options behavior.

### DIFF
--- a/options.go
+++ b/options.go
@@ -66,6 +66,7 @@ type ReflectConfiguration struct {
 	IsTableNamePlural      bool
 	TableAliasLength       *int
 	PrimaryKeyColumns      []string
+	ColumnNameMappings     map[string]string
 }
 
 // HasTableName indicates if the table name is set.
@@ -171,6 +172,12 @@ func (c *ReflectConfiguration) PluralTableName() bool {
 // HasTableAliasLength indicates if the table alias length is set.
 func (c *ReflectConfiguration) HasTableAliasLength() bool {
 	return c.TableAliasLength != nil
+}
+
+// HasColumnNameMappings indicates if any explicit column name mappings have
+// been set.
+func (c *ReflectConfiguration) HasColumnNameMappings() bool {
+	return len(c.ColumnNameMappings) > 0
 }
 
 var (
@@ -287,6 +294,18 @@ var (
 			}
 			pks := append([]string{}, names...)
 			c.PrimaryKeyColumns = pks
+		}
+	}
+
+	// WithColumnNameMapping specifies a single column mapping between the provided
+	// field name and column name. Both the field name and column name are case
+	// sensitive, and the name provided will be used regardless of other options specified.
+	WithColumnNameMapping = func(field, name string) ReflectOption {
+		return func(c *ReflectConfiguration) {
+			if c.ColumnNameMappings == nil {
+				c.ColumnNameMappings = make(map[string]string)
+			}
+			c.ColumnNameMappings[field] = name
 		}
 	}
 )

--- a/options.go
+++ b/options.go
@@ -43,6 +43,7 @@ var (
 		WithInferredTableName(DefaultTableNameStrategy, true),
 		WithInferredTableAlias(DefaultTableAliasStrategy, DefaultTableAliasLength),
 		WithInferredColumnNames(DefaultColumnNameStrategy),
+		WithoutMatchingMethods("^Set.*"),
 		WithPrimaryKeyColumn("id"),
 	}
 )

--- a/reflect.go
+++ b/reflect.go
@@ -158,6 +158,11 @@ func fields(t reflect.Type, v reflect.Value, c ReflectConfiguration) []Column {
 
 		var column Column
 		column.SetField(fieldName)
+		if c.HasColumnNameMappings() {
+			if cName, ok := c.ColumnNameMappings[fieldName]; ok {
+				columnName = cName
+			}
+		}
 		column.SetName(columnName)
 		if slices.Contains(c.PrimaryKeyColumns, columnName) {
 			column.SetPrimaryKey(true)
@@ -225,6 +230,11 @@ func methods(t reflect.Type, c ReflectConfiguration) []Column {
 
 		var column Column
 		column.SetField(fieldName)
+		if c.HasColumnNameMappings() {
+			if cName, ok := c.ColumnNameMappings[fieldName]; ok {
+				columnName = cName
+			}
+		}
 		column.SetName(columnName)
 		if slices.Contains(c.PrimaryKeyColumns, columnName) {
 			column.SetPrimaryKey(true)

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -720,6 +720,43 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				return t
 			},
 		},
+		{
+			name:    "WithColumnNameMapping",
+			obj:     s.obj,
+			options: []morph.ReflectOption{morph.WithColumnNameMapping("Name", "given_name")},
+			expected: func() morph.Table {
+				t := morph.Table{}
+				t.SetType(s.obj)
+				t.SetName("test_models")
+				t.SetAlias("T")
+
+				columns := []morph.Column{}
+
+				var idColumn morph.Column
+				idColumn.SetName("id")
+				idColumn.SetField("ID")
+				idColumn.SetPrimaryKey(true)
+				idColumn.SetStrategy(morph.FieldStrategyStructField)
+				idColumn.SetFieldType("int")
+
+				var nameColumn morph.Column
+				nameColumn.SetName("given_name")
+				nameColumn.SetField("Name")
+				nameColumn.SetPrimaryKey(false)
+				nameColumn.SetStrategy(morph.FieldStrategyStructField)
+				nameColumn.SetFieldType("*string")
+
+				var createdAtColumn morph.Column
+				createdAtColumn.SetName("created_at")
+				createdAtColumn.SetField("CreatedAt")
+				createdAtColumn.SetPrimaryKey(false)
+				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
+				createdAtColumn.SetFieldType("time.Time")
+
+				t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...)
+				return t
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1473,6 +1510,43 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetName("created_at")
 				createdAtColumn.SetField("CreatedAt")
 				createdAtColumn.SetPrimaryKey(true)
+				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
+				createdAtColumn.SetFieldType("time.Time")
+
+				t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...)
+				return t
+			},
+		},
+		{
+			name:    "WithColumnNameMapping",
+			obj:     s.objPtr,
+			options: []morph.ReflectOption{morph.WithColumnNameMapping("Name", "given_name")},
+			expected: func() morph.Table {
+				t := morph.Table{}
+				t.SetType(s.objPtr)
+				t.SetName("test_models")
+				t.SetAlias("T")
+
+				columns := []morph.Column{}
+
+				var idColumn morph.Column
+				idColumn.SetName("id")
+				idColumn.SetField("ID")
+				idColumn.SetPrimaryKey(true)
+				idColumn.SetStrategy(morph.FieldStrategyStructField)
+				idColumn.SetFieldType("int")
+
+				var nameColumn morph.Column
+				nameColumn.SetName("given_name")
+				nameColumn.SetField("Name")
+				nameColumn.SetPrimaryKey(false)
+				nameColumn.SetStrategy(morph.FieldStrategyStructField)
+				nameColumn.SetFieldType("*string")
+
+				var createdAtColumn morph.Column
+				createdAtColumn.SetName("created_at")
+				createdAtColumn.SetField("CreatedAt")
+				createdAtColumn.SetPrimaryKey(false)
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -79,7 +79,7 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 			err:     morph.ErrNotStruct,
 		},
 		{
-			name:    "WithNoOptions_Success",
+			name:    "WithNoOptions_AppliesDefaults",
 			obj:     s.obj,
 			options: []morph.ReflectOption{},
 			expected: func() morph.Table {
@@ -254,7 +254,7 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 			},
 		},
 		{
-			name:    "WithInferredTableName_Singular_Success",
+			name:    "WithInferredTableName_Singular_SetsTableNameWithSingular",
 			obj:     s.obj,
 			options: []morph.ReflectOption{morph.WithInferredTableName(morph.SnakeCaseStrategy, false)},
 			expected: func() morph.Table {
@@ -289,7 +289,7 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 			},
 		},
 		{
-			name:    "WithInferredTableName_CamelCase_Success",
+			name:    "WithInferredTableName_CamelCase_SetsTableNameToCamelCase",
 			obj:     s.obj,
 			options: []morph.ReflectOption{morph.WithInferredTableName(morph.CamelCaseStrategy, true)},
 			expected: func() morph.Table {
@@ -505,7 +505,7 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 			},
 		},
 		{
-			name:    "WithTableName_Success",
+			name:    "WithTableName_SetsTableName",
 			obj:     s.obj,
 			options: []morph.ReflectOption{morph.WithTableName("TEST_MOD")},
 			expected: func() morph.Table {
@@ -540,7 +540,7 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 			},
 		},
 		{
-			name:    "WithTableAlias_Success",
+			name:    "WithTableAlias_SetsTableAlias",
 			obj:     s.obj,
 			options: []morph.ReflectOption{morph.WithTableAlias("tm1")},
 			expected: func() morph.Table {
@@ -575,7 +575,7 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 			},
 		},
 		{
-			name:    "WithTag_Success",
+			name:    "WithTag_SetsTag",
 			obj:     s.obj,
 			options: []morph.ReflectOption{morph.WithTag("db")},
 			expected: func() morph.Table {
@@ -609,7 +609,7 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 			},
 		},
 		{
-			name:    "WithoutMethods_Success",
+			name:    "WithoutMethods_SetsMethodExclusions",
 			obj:     s.obj,
 			options: []morph.ReflectOption{morph.WithoutMethods("CreatedAt")},
 			expected: func() morph.Table {
@@ -638,7 +638,7 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 			},
 		},
 		{
-			name:    "WithoutMatchingMethods_Success",
+			name:    "WithoutMatchingMethods_SetsMethodExclusionPatterns",
 			obj:     s.obj,
 			options: []morph.ReflectOption{morph.WithoutMatchingMethods("^CreatedAt$")},
 			expected: func() morph.Table {
@@ -667,7 +667,7 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 			},
 		},
 		{
-			name:    "WithoutFields_Success",
+			name:    "WithoutFields_SetsFieldExclusions",
 			obj:     s.obj,
 			options: []morph.ReflectOption{morph.WithoutFields("Name")},
 			expected: func() morph.Table {
@@ -696,7 +696,7 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 			},
 		},
 		{
-			name:    "WithoutMatchingFields_Success",
+			name:    "WithoutMatchingFields_SetsFieldExclusionPatterns",
 			obj:     s.obj,
 			options: []morph.ReflectOption{morph.WithoutMatchingFields("^Name$")},
 			expected: func() morph.Table {
@@ -801,7 +801,7 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 			err:     morph.ErrNotStruct,
 		},
 		{
-			name:    "WithNoOptions_Success",
+			name:    "WithNoOptions_AppliesDefaults",
 			obj:     s.objPtr,
 			options: []morph.ReflectOption{},
 			expected: func() morph.Table {
@@ -976,7 +976,7 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 			},
 		},
 		{
-			name:    "WithInferredTableName_Singular_Success",
+			name:    "WithInferredTableName_Singular_SetsTableNameWithSingular",
 			obj:     s.objPtr,
 			options: []morph.ReflectOption{morph.WithInferredTableName(morph.SnakeCaseStrategy, false)},
 			expected: func() morph.Table {
@@ -1011,7 +1011,7 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 			},
 		},
 		{
-			name:    "WithInferredTableName_CamelCase_Success",
+			name:    "WithInferredTableName_CamelCase_SetsTableNameToCamelCase",
 			obj:     s.objPtr,
 			options: []morph.ReflectOption{morph.WithInferredTableName(morph.CamelCaseStrategy, true)},
 			expected: func() morph.Table {
@@ -1227,7 +1227,7 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 			},
 		},
 		{
-			name:    "WithTableName_Success",
+			name:    "WithTableName_SetsTableName",
 			obj:     s.objPtr,
 			options: []morph.ReflectOption{morph.WithTableName("TEST_MOD")},
 			expected: func() morph.Table {
@@ -1262,7 +1262,7 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 			},
 		},
 		{
-			name:    "WithTableAlias_Success",
+			name:    "WithTableAlias_SetsTableAlias",
 			obj:     s.objPtr,
 			options: []morph.ReflectOption{morph.WithTableAlias("tm1")},
 			expected: func() morph.Table {
@@ -1297,7 +1297,7 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 			},
 		},
 		{
-			name:    "WithTag_Success",
+			name:    "WithTag_SetsTag",
 			obj:     s.objPtr,
 			options: []morph.ReflectOption{morph.WithTag("db")},
 			expected: func() morph.Table {
@@ -1332,7 +1332,7 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 			},
 		},
 		{
-			name:    "WithoutMethods_Success",
+			name:    "WithoutMethods_SetsMethodExclusions",
 			obj:     s.objPtr,
 			options: []morph.ReflectOption{morph.WithoutMethods("CreatedAt")},
 			expected: func() morph.Table {
@@ -1361,7 +1361,7 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 			},
 		},
 		{
-			name:    "WithoutMatchingMethods_Success",
+			name:    "WithoutMatchingMethods_SetsMethodExclusionPatterns",
 			obj:     s.objPtr,
 			options: []morph.ReflectOption{morph.WithoutMatchingMethods("^CreatedAt$")},
 			expected: func() morph.Table {
@@ -1390,7 +1390,7 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 			},
 		},
 		{
-			name:    "WithoutFields_Success",
+			name:    "WithoutFields_SetsFieldExclusions",
 			obj:     s.objPtr,
 			options: []morph.ReflectOption{morph.WithoutFields("Name")},
 			expected: func() morph.Table {
@@ -1419,7 +1419,7 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 			},
 		},
 		{
-			name:    "WithoutMatchingFields_Success",
+			name:    "WithoutMatchingFields_SetsFieldExclusionPatterns",
 			obj:     s.objPtr,
 			options: []morph.ReflectOption{morph.WithoutMatchingFields("^Name$")},
 			expected: func() morph.Table {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -22,6 +22,10 @@ func (t TestModel) Ignored() {
 	return
 }
 
+func (t *TestModel) SetName(name string) {
+	t.Name = &name
+}
+
 func (t TestModel) AnotherPtr() *AnotherTestModel {
 	return &t.Another
 }


### PR DESCRIPTION
**Description**

These changes automatically expend reflection option behavior such that:

- by default, all methods that start with `"Set"` will be excluded.
  - as outlined in Effective Go, setters should start with `"Set"`, and setters are not eligible for this reflection behavior.
- a new options, `WithColumnNameMapping`, can be provided to override the default name determined for a column. 

**Rationale**

- Without `WithColumnNameMapping`, the only way specify a custom name is by constructing the entire column definition (either through code or via file definition). This makes it far more convenient.
- Using Effective Go as a guide, we are able to safely exclude methods that would conventionally be identified as "setters" from being included within the reflection process.

**Suggested Version**

`v1.2.0`

**Example Usage**

```go
obj := Foo{
  FirstName: "Han",
  LastName: "Solo",
}

table, err := morph.Reflect(obj, morph.WithColumnNameMapping("FirstName", "given_name"))
if err != nil {
  panic(err)
}
```
