### PR TITLE
Introduce "must" and "with args" query method variants.

### DIFF
--- a/must.go
+++ b/must.go
@@ -1,0 +1,9 @@
+package morph
+
+// Must panics if the error is not nil.
+func Must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}


### PR DESCRIPTION
**Description**

Introduces the following "must" variants:

- `MustInsertQuery`
- `MustUpdatetQuery`
- `MustDeleteQuery`

Introduces the following "with arg" variants:

- `InsertQueryWithArgs`
- `UpdateQueryWithArgs`
- `DeleteQueryWithArgs`

**Rationale**

The "must" variants are purely convenience - often the circumstances that result in errors when generating queries can be avoid with proper care. The "with arg" variants are to assist when the query is planned to be executed using the `Exec` and `ExecContext` variants of the `sql` package.

**Suggested Version**

`v1.3.0`

**Example Usage**

```golang
obj := //...
db := //...
ctx := context.Background()

query, args, err := dm.table.DeleteQueryWithArgs(obj)
if err != nil {
  return err
}

tx, err := db.BeginTx(ctx, nil)
if err != nil {
  return err
}

stmt, err := tx.Prepare(query)
if err != nil {
  return err
}
defer stmt.Close()

_, err = stmt.ExecContext(ctx, args)
if err != nil {
  return err
}
```
