### PR TITLE
Convert 'interface{}' to 'any'.

### DIFF
--- a/query.go
+++ b/query.go
@@ -14,7 +14,7 @@ type QueryOptions struct {
 	Ordered     bool
 	Named       bool
 	OmitEmpty   bool
-	obj         interface{}
+	obj         any
 }
 
 // QueryOption represents a function that modifies the query options.
@@ -47,7 +47,7 @@ func WithNamedParameters() QueryOption {
 }
 
 // WithoutEmptyValues indicates that columns with no value should be omitted from the query.
-func WithoutEmptyValues(obj interface{}) QueryOption {
+func WithoutEmptyValues(obj any) QueryOption {
 	return func(q *QueryOptions) {
 		q.OmitEmpty = true
 		q.obj = obj

--- a/reflect.go
+++ b/reflect.go
@@ -22,7 +22,7 @@ var (
 
 // Reflect observes the provided object and generates metadata from it
 // using the provided options.
-func Reflect(obj interface{}, options ...ReflectOption) (Table, error) {
+func Reflect(obj any, options ...ReflectOption) (Table, error) {
 	t := reflect.TypeOf(obj)
 	val := reflect.ValueOf(obj)
 	if t.Kind() == reflect.Ptr {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -38,8 +38,8 @@ type AnotherTestModel struct {
 type ReflectTestSuite struct {
 	suite.Suite
 
-	obj    interface{}
-	objPtr interface{}
+	obj    any
+	objPtr any
 }
 
 func TestReflectTestSuite(t *testing.T) {
@@ -66,7 +66,7 @@ func (s *ReflectTestSuite) SetupTest() {
 func (s *ReflectTestSuite) TestReflect_WithValue() {
 	tests := []struct {
 		name     string
-		obj      interface{}
+		obj      any
 		options  []morph.ReflectOption
 		expected func() morph.Table
 		err      error
@@ -828,7 +828,7 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 
 	tests := []struct {
 		name     string
-		obj      interface{}
+		obj      any
 		options  []morph.ReflectOption
 		expected func() morph.Table
 		err      error

--- a/table.go
+++ b/table.go
@@ -45,7 +45,7 @@ var (
 )
 
 // EvaluationResult represents the result of evaluating a table against an object.
-type EvaluationResult map[string]interface{}
+type EvaluationResult map[string]any
 
 // Empties retrieves all of the keys in the result that have nil values.
 func (r EvaluationResult) Empties() []string {
@@ -79,7 +79,7 @@ type Table struct {
 }
 
 // SetType associates the entity type to the table.
-func (t *Table) SetType(entity interface{}) {
+func (t *Table) SetType(entity any) {
 	t.SetTypeName(fmt.Sprintf("%T", entity))
 }
 
@@ -203,7 +203,7 @@ func (t *Table) AddColumns(columns ...Column) error {
 // Evaluate applies the table to the provided object to produce a result
 // containing the column names and their respective values. The result
 // can then be subsequently used to execute queries.
-func (t *Table) Evaluate(obj interface{}) (EvaluationResult, error) {
+func (t *Table) Evaluate(obj any) (EvaluationResult, error) {
 	objType := reflect.TypeOf(obj)
 	objVal := reflect.ValueOf(obj)
 
@@ -289,7 +289,7 @@ func (t *Table) Evaluate(obj interface{}) (EvaluationResult, error) {
 }
 
 // MustEvaluate performs the same operation as Evaluate but panics if an error occurs.
-func (t *Table) MustEvaluate(obj interface{}) EvaluationResult {
+func (t *Table) MustEvaluate(obj any) EvaluationResult {
 	results, err := t.Evaluate(obj)
 	if err != nil {
 		panic(err)
@@ -367,7 +367,7 @@ func (t *Table) query(tmpl *template.Template, options ...QueryOption) (string, 
 	return buf.String(), nil
 }
 
-func (t *Table) queryWithArgs(namedQuery string, obj interface{}, options ...QueryOption) (string, []interface{}, error) {
+func (t *Table) queryWithArgs(namedQuery string, obj any, options ...QueryOption) (string, []any, error) {
 	qo := &QueryOptions{}
 	opts := append(DefaultQueryOptions, options...)
 	for _, opt := range opts {
@@ -379,7 +379,7 @@ func (t *Table) queryWithArgs(namedQuery string, obj interface{}, options ...Que
 		return "", nil, err
 	}
 
-	args := []interface{}{}
+	args := []any{}
 	missing := []string{}
 
 	count := 0
@@ -413,7 +413,7 @@ func (t *Table) InsertQuery(options ...QueryOption) (string, error) {
 
 // InsertQueryWithArgs generates an insert query for the table along with arguments
 // derived from the provided object.
-func (t *Table) InsertQueryWithArgs(obj interface{}, options ...QueryOption) (string, []interface{}, error) {
+func (t *Table) InsertQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
 	query, err := t.InsertQuery(append(options, WithNamedParameters())...)
 	if err != nil {
 		return "", nil, err
@@ -434,7 +434,7 @@ func (t *Table) UpdateQuery(options ...QueryOption) (string, error) {
 
 // UpdateQueryWithArgs generates an update query for the table along with arguments
 // derived from the provided object.
-func (t *Table) UpdateQueryWithArgs(obj interface{}, options ...QueryOption) (string, []interface{}, error) {
+func (t *Table) UpdateQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
 	query, err := t.UpdateQuery(append(options, WithNamedParameters())...)
 	if err != nil {
 		return "", nil, err
@@ -455,7 +455,7 @@ func (t *Table) DeleteQuery(options ...QueryOption) (string, error) {
 
 // DeleteQueryWithArgs generates a delete query for the table along with arguments
 // derived from the provided object.
-func (t *Table) DeleteQueryWithArgs(obj interface{}, options ...QueryOption) (string, []interface{}, error) {
+func (t *Table) DeleteQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
 	query, err := t.DeleteQuery(append(options, WithNamedParameters())...)
 	if err != nil {
 		return "", nil, err

--- a/table_test.go
+++ b/table_test.go
@@ -787,7 +787,7 @@ func (s *TableTestSuite) TestTable_MustEvaluatePointer() {
 func (s *TableTestSuite) TestTable_EvaluateErrors() {
 	tests := []struct {
 		name         string
-		obj          interface{}
+		obj          any
 		preparations func()
 		err          error
 	}{
@@ -1133,7 +1133,7 @@ func (s *TableTestSuite) TestTable_InsertQueryWithArgs() {
 		name         string
 		queryOptions []morph.QueryOption
 		preparations func() TestModel
-		assertions   func(obj TestModel, query string, args []interface{}, err error)
+		assertions   func(obj TestModel, query string, args []any, err error)
 	}{
 		{
 			name:         "NoOptions",
@@ -1150,10 +1150,10 @@ func (s *TableTestSuite) TestTable_InsertQueryWithArgs() {
 					},
 				}
 			},
-			assertions: func(obj TestModel, query string, args []interface{}, err error) {
+			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
 				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES (?, ?, ?);", query)
-				s.ElementsMatch([]interface{}{obj.CreatedAt(), obj.ID, *obj.Name}, args)
+				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID, *obj.Name}, args)
 			},
 		},
 		{
@@ -1171,10 +1171,10 @@ func (s *TableTestSuite) TestTable_InsertQueryWithArgs() {
 					},
 				}
 			},
-			assertions: func(obj TestModel, query string, args []interface{}, err error) {
+			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
 				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES ($, $, $);", query)
-				s.ElementsMatch([]interface{}{obj.CreatedAt(), obj.ID, *obj.Name}, args)
+				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID, *obj.Name}, args)
 			},
 		},
 		{
@@ -1192,10 +1192,10 @@ func (s *TableTestSuite) TestTable_InsertQueryWithArgs() {
 					},
 				}
 			},
-			assertions: func(obj TestModel, query string, args []interface{}, err error) {
+			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
 				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES ($1, $2, $3);", query)
-				s.ElementsMatch([]interface{}{obj.CreatedAt(), obj.ID, *obj.Name}, args)
+				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID, *obj.Name}, args)
 			},
 		},
 	}
@@ -1505,7 +1505,7 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 		name         string
 		queryOptions func(m TestModel) []morph.QueryOption
 		preparations func() TestModel
-		assertions   func(obj TestModel, query string, args []interface{}, err error)
+		assertions   func(obj TestModel, query string, args []any, err error)
 	}{
 		{
 			name:         "NoOptions",
@@ -1522,10 +1522,10 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 					},
 				}
 			},
-			assertions: func(obj TestModel, query string, args []interface{}, err error) {
+			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
 				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.name = ? WHERE 1=1 AND T.id = ?;", query)
-				s.ElementsMatch([]interface{}{obj.CreatedAt(), *obj.Name, obj.ID}, args)
+				s.ElementsMatch([]any{obj.CreatedAt(), *obj.Name, obj.ID}, args)
 			},
 		},
 		{
@@ -1542,10 +1542,10 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 					},
 				}
 			},
-			assertions: func(obj TestModel, query string, args []interface{}, err error) {
+			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
 				s.Equal("UPDATE test_models AS T SET T.created_at = ? WHERE 1=1 AND T.id = ?;", query)
-				s.ElementsMatch([]interface{}{obj.CreatedAt(), obj.ID}, args)
+				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID}, args)
 			},
 		},
 		{
@@ -1563,10 +1563,10 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 					},
 				}
 			},
-			assertions: func(obj TestModel, query string, args []interface{}, err error) {
+			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
 				s.Equal("UPDATE test_models AS T SET T.created_at = $, T.name = $ WHERE 1=1 AND T.id = $;", query)
-				s.ElementsMatch([]interface{}{obj.CreatedAt(), *obj.Name, obj.ID}, args)
+				s.ElementsMatch([]any{obj.CreatedAt(), *obj.Name, obj.ID}, args)
 			},
 		},
 		{
@@ -1584,10 +1584,10 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 					},
 				}
 			},
-			assertions: func(obj TestModel, query string, args []interface{}, err error) {
+			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
 				s.Equal("UPDATE test_models AS T SET T.created_at = $1, T.name = $2 WHERE 1=1 AND T.id = $3;", query)
-				s.ElementsMatch([]interface{}{obj.CreatedAt(), *obj.Name, obj.ID}, args)
+				s.ElementsMatch([]any{obj.CreatedAt(), *obj.Name, obj.ID}, args)
 			},
 		},
 	}
@@ -1859,7 +1859,7 @@ func (s *TableTestSuite) TestTable_DeleteQueryWithArgs() {
 		name         string
 		queryOptions []morph.QueryOption
 		preparations func() TestModel
-		assertions   func(obj TestModel, query string, args []interface{}, err error)
+		assertions   func(obj TestModel, query string, args []any, err error)
 	}{
 		{
 			name:         "NoOptions",
@@ -1876,10 +1876,10 @@ func (s *TableTestSuite) TestTable_DeleteQueryWithArgs() {
 					},
 				}
 			},
-			assertions: func(obj TestModel, query string, args []interface{}, err error) {
+			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
 				s.Equal("DELETE FROM test_models WHERE 1=1 AND id = ?;", query)
-				s.ElementsMatch([]interface{}{obj.ID}, args)
+				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},
 		{
@@ -1897,10 +1897,10 @@ func (s *TableTestSuite) TestTable_DeleteQueryWithArgs() {
 					},
 				}
 			},
-			assertions: func(obj TestModel, query string, args []interface{}, err error) {
+			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
 				s.Equal("DELETE FROM test_models WHERE 1=1 AND id = $;", query)
-				s.ElementsMatch([]interface{}{obj.ID}, args)
+				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},
 		{
@@ -1918,10 +1918,10 @@ func (s *TableTestSuite) TestTable_DeleteQueryWithArgs() {
 					},
 				}
 			},
-			assertions: func(obj TestModel, query string, args []interface{}, err error) {
+			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
 				s.Equal("DELETE FROM test_models WHERE 1=1 AND id = $1;", query)
-				s.ElementsMatch([]interface{}{obj.ID}, args)
+				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},
 	}


### PR DESCRIPTION
**Description**

These changes replace all references to the empty interface ( `interface{}` ) with `any`.

**Rationale**

Mainly cosmetic, but brings the code up to modern best practices and prevents editor / IDE warnings.

**Suggested Version**

N/A

**Example Usage**

N/A
