### PR TITLE
Introduce initial set of the benchmarks.

### DIFF
--- a/.github/workflows/cb.yaml
+++ b/.github/workflows/cb.yaml
@@ -1,0 +1,37 @@
+name: CB
+on: [push]
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.24"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Run benchmark
+        run: go test -C internal -run XXX -bench=. | tee output.txt
+      - name: Download previous benchmark data
+        uses: actions/cache@v4
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: "go"
+          output-file-path: output.txt
+          external-data-json-path: ./cache/benchmark-data.json
+          fail-on-alert: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-always: true
+          comment-on-alert: true
+          alert-comment-cc-users: "@fr33r"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64
+          version: v1.64.7
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on: [push]
 jobs:
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.24"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}

--- a/internal/benchmark_test.go
+++ b/internal/benchmark_test.go
@@ -1,0 +1,486 @@
+package morph_benchmark
+
+import (
+	"testing"
+
+	"github.com/freerware/morph"
+)
+
+type Starship struct {
+	ID         int     `morph:"id"`
+	Name       string  `morph:"ship_name"`
+	Category   string  `morph:"category"`
+	Class      string  `morph:"class"`
+	Length     float64 `morph:"length"`
+	LengthUnit string  `morph:"length_unit"`
+	Crew       int     `morph:"crew_capacity"`
+	Speed      float64 `morph:"max_speed"`
+	SpeedUnit  string  `morph:"speed_unit"`
+}
+
+var (
+	millenniumFalcon = Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+)
+
+func BenchmarkReflect_DefaultOptions(b *testing.B) {
+	for b.Loop() {
+		_, err := morph.Reflect(millenniumFalcon)
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReflect_WithTag(b *testing.B) {
+	for b.Loop() {
+		_, err := morph.Reflect(millenniumFalcon, morph.WithTag("morph"))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReflect_WithoutFields(b *testing.B) {
+	for b.Loop() {
+		_, err := morph.Reflect(millenniumFalcon, morph.WithoutFields("Length", "LengthUnit", "Speed", "SpeedUnit"))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReflect_WithoutMatchingFields(b *testing.B) {
+	for b.Loop() {
+		_, err := morph.Reflect(millenniumFalcon, morph.WithoutMatchingFields(`^\w+Unit`))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReflect_WithPrimaryKeyColumn(b *testing.B) {
+	for b.Loop() {
+		_, err := morph.Reflect(millenniumFalcon, morph.WithPrimaryKeyColumn("ID"))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReflect_WithPrimaryKeyColumns(b *testing.B) {
+	for b.Loop() {
+		_, err := morph.Reflect(millenniumFalcon, morph.WithPrimaryKeyColumns([]string{"ID"}))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReflect_WithTableName(b *testing.B) {
+	for b.Loop() {
+		_, err := morph.Reflect(millenniumFalcon, morph.WithTableName("RazorCrest"))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableInsertQuery_DefaultOptions(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, err := table.InsertQuery()
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableInsertQuery_WithPlaceholder(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, err := table.InsertQuery(morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableInsertQuery_WithNamedParameters(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, err := table.InsertQuery(morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableUpdateQuery_DefaultOptions(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, err := table.UpdateQuery()
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableUpdateQuery_WithPlaceholder(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, err := table.UpdateQuery(morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableUpdateQuery_WithNamedParameters(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, err := table.UpdateQuery(morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableUpdateQuery_WithoutEmptyValues(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, err := table.UpdateQuery(morph.WithoutEmptyValues(millenniumFalcon))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableDeleteQuery_DefaultOptions(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, err := table.DeleteQuery()
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableDeleteQuery_WithPlaceholder(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, err := table.DeleteQuery(morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableDeleteQuery_WithNamedParameters(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, err := table.DeleteQuery(morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableMustInsertQuery_DefaultOptions(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		table.MustInsertQuery()
+	}
+}
+
+func BenchmarkTableMustInsertQuery_WithPlaceholder(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		table.MustInsertQuery(morph.WithPlaceholder("$", true))
+	}
+}
+
+func BenchmarkTableMustInsertQuery_WithNamedParameters(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		table.MustInsertQuery(morph.WithNamedParameters())
+	}
+}
+
+func BenchmarkTableMustUpdateQuery_DefaultOptions(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		table.MustUpdateQuery()
+	}
+}
+
+func BenchmarkTableMustUpdateQuery_WithPlaceholder(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		table.MustUpdateQuery(morph.WithPlaceholder("$", true))
+	}
+}
+
+func BenchmarkTableMustUpdateQuery_WithNamedParameters(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		table.MustUpdateQuery(morph.WithNamedParameters())
+	}
+}
+
+func BenchmarkTableMustUpdateQuery_WithoutEmptyValues(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		table.MustUpdateQuery(morph.WithoutEmptyValues(millenniumFalcon))
+	}
+}
+
+func BenchmarkTableMustDeleteQuery_DefaultOptions(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		table.MustDeleteQuery()
+	}
+}
+
+func BenchmarkTableMustDeleteQuery_WithPlaceholder(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		table.MustDeleteQuery(morph.WithPlaceholder("$", true))
+	}
+}
+
+func BenchmarkTableMustDeleteQuery_WithNamedParameters(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		table.MustDeleteQuery(morph.WithNamedParameters())
+	}
+}
+
+func BenchmarkTableInsertQueryWithArgs_DefaultOptions(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, _, err := table.InsertQueryWithArgs(millenniumFalcon)
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableInsertQueryWithArgs_WithPlaceholder(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, _, err := table.InsertQueryWithArgs(millenniumFalcon, morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableInsertQueryWithArgs_WithNamedParameters(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, _, err := table.InsertQueryWithArgs(millenniumFalcon, morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableUpdateQueryWithArgs_DefaultOptions(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, _, err := table.UpdateQueryWithArgs(millenniumFalcon)
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableUpdateQueryWithArgs_WithPlaceholder(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, _, err := table.UpdateQueryWithArgs(millenniumFalcon, morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableUpdateQueryWithArgs_WithNamedParameters(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, _, err := table.UpdateQueryWithArgs(millenniumFalcon, morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableUpdateQueryWithArgs_WithoutEmptyValues(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, _, err := table.UpdateQueryWithArgs(millenniumFalcon, morph.WithoutEmptyValues(millenniumFalcon))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableDeleteQueryWithArgs_DefaultOptions(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, _, err := table.DeleteQueryWithArgs(millenniumFalcon)
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableDeleteQueryWithArgs_WithPlaceholder(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, _, err := table.DeleteQueryWithArgs(millenniumFalcon, morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableDeleteQueryWithArgs_WithNamedParameters(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, _, err := table.DeleteQueryWithArgs(millenniumFalcon, morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}


### PR DESCRIPTION
**Description**

Defines an initial set of benchmarks in `internal/benchmark_test.go` and adds a Github workflow for continuous benchmarking.

**Rationale**

Given how performance critical the persistence process can be in many systems, it is important to provide visibility into `morph`s performance and provide a mechanism for detecting if changes add any performance regressions.

**Suggested Version**

N/A

**Example Usage**

N/A
