### PR TITLE
Use variadic param for option instead of slice.

### DIFF
--- a/internal/benchmark_test.go
+++ b/internal/benchmark_test.go
@@ -79,7 +79,7 @@ func BenchmarkReflect_WithPrimaryKeyColumn(b *testing.B) {
 
 func BenchmarkReflect_WithPrimaryKeyColumns(b *testing.B) {
 	for b.Loop() {
-		_, err := morph.Reflect(millenniumFalcon, morph.WithPrimaryKeyColumns([]string{"ID"}))
+		_, err := morph.Reflect(millenniumFalcon, morph.WithPrimaryKeyColumns("ID"))
 		if err != nil {
 			b.FailNow()
 		}

--- a/options.go
+++ b/options.go
@@ -288,7 +288,7 @@ var (
 
 	// WithPrimaryKeyColumns specifies the names of the column that acts together as
 	// the primary key.
-	WithPrimaryKeyColumns = func(names []string) ReflectOption {
+	WithPrimaryKeyColumns = func(names ...string) ReflectOption {
 		return func(c *ReflectConfiguration) {
 			if c.PrimaryKeyColumns == nil {
 				c.PrimaryKeyColumns = []string{}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -1566,7 +1566,7 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 		{
 			name:    "WithPrimaryKeyColumns",
 			obj:     s.objPtr,
-			options: []morph.ReflectOption{morph.WithPrimaryKeyColumns([]string{"id", "created_at"})},
+			options: []morph.ReflectOption{morph.WithPrimaryKeyColumns("id", "created_at")},
 			expected: func() morph.Table {
 				t := morph.Table{}
 				t.SetType(s.objPtr)


### PR DESCRIPTION
**Description**

I accidentally used a slice as the parameter type for the `WithPrimaryKeyColumns` option. These changes fix it to be variadic.

**Rationale**

While technically a breaking change for this option, we are early enough and the blast radius is small enough where this change is worth shuttling in.

**Suggested Version**

`v1.3.0`

**Example Usage**

```go
...

_, err := morph.Reflect(millenniumFalcon, morph.WithPrimaryKeyColumns("ID"))

...
```
