### PR TITLE
Introduce SELECT query functionality.

### DIFF
--- a/.github/workflows/cb.yaml
+++ b/.github/workflows/cb.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Run benchmark
-        run: go test -C internal -run XXX -bench=. | tee output.txt
+        run: make benchmarks | tee output.txt
       - name: Download previous benchmark data
         uses: actions/cache@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ bins:
 
 tests: bins
 	go test -v -race -covermode=atomic -coverprofile=morph.coverprofile
+
+benchmarks: bins
+	go test -C internal -run XXX -bench=.

--- a/internal/benchmark_test.go
+++ b/internal/benchmark_test.go
@@ -235,6 +235,48 @@ func BenchmarkTableDeleteQuery_WithNamedParameters(b *testing.B) {
 	}
 }
 
+func BenchmarkTableSelectQuery_DefaultOptions(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, err := table.SelectQuery()
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableSelectQuery_WithPlaceholder(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, err := table.SelectQuery(morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableSelectQuery_WithNamedParameters(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, err := table.SelectQuery(morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
 func BenchmarkTableMustInsertQuery_DefaultOptions(b *testing.B) {
 	table, err := morph.Reflect(millenniumFalcon)
 	if err != nil {
@@ -342,6 +384,39 @@ func BenchmarkTableMustDeleteQuery_WithNamedParameters(b *testing.B) {
 
 	for b.Loop() {
 		table.MustDeleteQuery(morph.WithNamedParameters())
+	}
+}
+
+func BenchmarkTableMustSelectQuery_DefaultOptions(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		table.MustSelectQuery()
+	}
+}
+
+func BenchmarkTableMustSelectQuery_WithPlaceholder(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		table.MustSelectQuery(morph.WithPlaceholder("$", true))
+	}
+}
+
+func BenchmarkTableMustSelectQuery_WithNamedParameters(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		table.MustSelectQuery(morph.WithNamedParameters())
 	}
 }
 
@@ -479,6 +554,48 @@ func BenchmarkTableDeleteQueryWithArgs_WithNamedParameters(b *testing.B) {
 
 	for b.Loop() {
 		_, _, err := table.DeleteQueryWithArgs(millenniumFalcon, morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableSelectQueryWithArgs_DefaultOptions(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, _, err := table.SelectQueryWithArgs(millenniumFalcon)
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableSelectQueryWithArgs_WithPlaceholder(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, _, err := table.SelectQueryWithArgs(millenniumFalcon, morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkTableSelectQueryWithArgs_WithNamedParameters(b *testing.B) {
+	table, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	for b.Loop() {
+		_, _, err := table.SelectQueryWithArgs(millenniumFalcon, morph.WithNamedParameters())
 		if err != nil {
 			b.FailNow()
 		}

--- a/query.go
+++ b/query.go
@@ -143,13 +143,13 @@ var (
 		},
 	}
 
-	// insertTmpl is the parsed template used to generate an insert query.
+	// insertTmpl is the parsed template used to generate an INSERT query.
 	insertTmpl = template.Must(template.New("insertQuery").Funcs(funcs).Parse(insertSQL))
 
-	// updateTmpl is the parsed template used to generate an update query.
+	// updateTmpl is the parsed template used to generate an UPDATE query.
 	updateTmpl = template.Must(template.New("updateQuery").Funcs(funcs).Parse(updateSQL))
 
-	// deleteTmpl is the parsed template used to generate a delete query.
+	// deleteTmpl is the parsed template used to generate a DELETE query.
 	deleteTmpl = template.Must(template.New("deleteQuery").Funcs(funcs).Parse(deleteSQL))
 
 	// selectTmpl is the parsed template used to generate a SELECT query.

--- a/query.go
+++ b/query.go
@@ -98,6 +98,19 @@ const deleteSQL = `
     {{- $seq = add $seq 1 }} AND {{.Name}} = {{param $col.Name $options $seq}}
   {{- end -}};`
 
+const selectSQL = `
+  {{- $table := .Table -}}
+  {{- $options := .Options -}}
+  {{- $seq := 0 -}}
+  SELECT {{- if true}} {{end}}
+  {{- range $idx, $col := $table.Columns -}}
+    {{$col.Name}}{{if ne $idx (sub (len $table.Columns) 1)}}, {{end}}
+  {{- end -}}
+  {{- if true}} {{end -}} FROM {{$table.Name}} AS {{$table.Alias}} WHERE 1=1
+  {{- range $idx, $col := .PrimaryKeys -}}
+    {{- $seq = add $seq 1 }} AND {{$table.Alias}}.{{.Name}} = {{param $col.Name $options $seq}}
+  {{- end -}};`
+
 var (
 	// funcs defines the custom functions leveraged within the query templates.
 	funcs = template.FuncMap{
@@ -138,4 +151,7 @@ var (
 
 	// deleteTmpl is the parsed template used to generate a delete query.
 	deleteTmpl = template.Must(template.New("deleteQuery").Funcs(funcs).Parse(deleteSQL))
+
+	// selectTmpl is the parsed template used to generate a SELECT query.
+	selectTmpl = template.Must(template.New("selectQuery").Funcs(funcs).Parse(selectSQL))
 )

--- a/table.go
+++ b/table.go
@@ -406,12 +406,12 @@ func (t *Table) queryWithArgs(namedQuery string, obj any, options ...QueryOption
 	return query, args, nil
 }
 
-// InsertQuery generates an insert query for the table.
+// InsertQuery generates an INSERT query for the table.
 func (t *Table) InsertQuery(options ...QueryOption) (string, error) {
 	return t.query(insertTmpl, options...)
 }
 
-// InsertQueryWithArgs generates an insert query for the table along with arguments
+// InsertQueryWithArgs generates an INSERT query for the table along with arguments
 // derived from the provided object.
 func (t *Table) InsertQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
 	query, err := t.InsertQuery(append(options, WithNamedParameters())...)
@@ -427,12 +427,12 @@ func (t *Table) MustInsertQuery(options ...QueryOption) string {
 	return Must(t.InsertQuery(options...))
 }
 
-// UpdateQuery generates an update query for the table.
+// UpdateQuery generates an UPDATE query for the table.
 func (t *Table) UpdateQuery(options ...QueryOption) (string, error) {
 	return t.query(updateTmpl, options...)
 }
 
-// UpdateQueryWithArgs generates an update query for the table along with arguments
+// UpdateQueryWithArgs generates an UPDATE query for the table along with arguments
 // derived from the provided object.
 func (t *Table) UpdateQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
 	query, err := t.UpdateQuery(append(options, WithNamedParameters())...)
@@ -448,12 +448,12 @@ func (t *Table) MustUpdateQuery(options ...QueryOption) string {
 	return Must(t.UpdateQuery(options...))
 }
 
-// DeleteQuery generates a delete query for the table.
+// DeleteQuery generates a DELETE query for the table.
 func (t *Table) DeleteQuery(options ...QueryOption) (string, error) {
 	return t.query(deleteTmpl, options...)
 }
 
-// DeleteQueryWithArgs generates a delete query for the table along with arguments
+// DeleteQueryWithArgs generates a DELETE query for the table along with arguments
 // derived from the provided object.
 func (t *Table) DeleteQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
 	query, err := t.DeleteQuery(append(options, WithNamedParameters())...)

--- a/table.go
+++ b/table.go
@@ -468,3 +468,24 @@ func (t *Table) DeleteQueryWithArgs(obj any, options ...QueryOption) (string, []
 func (t *Table) MustDeleteQuery(options ...QueryOption) string {
 	return Must(t.DeleteQuery(options...))
 }
+
+// SelectQuery generates a SELECT query for the table.
+func (t *Table) SelectQuery(options ...QueryOption) (string, error) {
+	return t.query(selectTmpl, options...)
+}
+
+// SelectQueryWithArgs generates a SELECT query for the table along with arguments
+// derived from the provided object.
+func (t *Table) SelectQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
+	query, err := t.SelectQuery(append(options, WithNamedParameters())...)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return t.queryWithArgs(query, obj, options...)
+}
+
+// MustSelectQuery performs the same operation as SelectQuery but panics if an error occurs.
+func (t *Table) MustSelectQuery(options ...QueryOption) string {
+	return Must(t.SelectQuery(options...))
+}

--- a/table.go
+++ b/table.go
@@ -414,12 +414,13 @@ func (t *Table) InsertQuery(options ...QueryOption) (string, error) {
 // InsertQueryWithArgs generates an INSERT query for the table along with arguments
 // derived from the provided object.
 func (t *Table) InsertQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
-	query, err := t.InsertQuery(append(options, WithNamedParameters())...)
+	opts := append(options, WithNamedParameters())
+	query, err := t.InsertQuery(opts...)
 	if err != nil {
 		return "", nil, err
 	}
 
-	return t.queryWithArgs(query, obj, options...)
+	return t.queryWithArgs(query, obj, opts...)
 }
 
 // MustInsertQuery performs the same operation as InsertQuery but panics if an error occurs.
@@ -435,12 +436,13 @@ func (t *Table) UpdateQuery(options ...QueryOption) (string, error) {
 // UpdateQueryWithArgs generates an UPDATE query for the table along with arguments
 // derived from the provided object.
 func (t *Table) UpdateQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
-	query, err := t.UpdateQuery(append(options, WithNamedParameters())...)
+	opts := append(options, WithNamedParameters())
+	query, err := t.UpdateQuery(opts...)
 	if err != nil {
 		return "", nil, err
 	}
 
-	return t.queryWithArgs(query, obj, options...)
+	return t.queryWithArgs(query, obj, opts...)
 }
 
 // MustUpdateQuery performs the same operation as UpdateQuery but panics if an error occurs.
@@ -456,12 +458,13 @@ func (t *Table) DeleteQuery(options ...QueryOption) (string, error) {
 // DeleteQueryWithArgs generates a DELETE query for the table along with arguments
 // derived from the provided object.
 func (t *Table) DeleteQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
-	query, err := t.DeleteQuery(append(options, WithNamedParameters())...)
+	opts := append(options, WithNamedParameters())
+	query, err := t.DeleteQuery(opts...)
 	if err != nil {
 		return "", nil, err
 	}
 
-	return t.queryWithArgs(query, obj, options...)
+	return t.queryWithArgs(query, obj, opts...)
 }
 
 // MustDeleteQuery performs the same operation as DeleteQuery but panics if an error occurs.
@@ -477,12 +480,13 @@ func (t *Table) SelectQuery(options ...QueryOption) (string, error) {
 // SelectQueryWithArgs generates a SELECT query for the table along with arguments
 // derived from the provided object.
 func (t *Table) SelectQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
-	query, err := t.SelectQuery(append(options, WithNamedParameters())...)
+	opts := append(options, WithNamedParameters())
+	query, err := t.SelectQuery(opts...)
 	if err != nil {
 		return "", nil, err
 	}
 
-	return t.queryWithArgs(query, obj, options...)
+	return t.queryWithArgs(query, obj, opts...)
 }
 
 // MustSelectQuery performs the same operation as SelectQuery but panics if an error occurs.

--- a/table_test.go
+++ b/table_test.go
@@ -1956,6 +1956,331 @@ func (s *TableTestSuite) TestTable_DeleteQueryWithArgs_InvalidTable() {
 	s.Empty(args)
 }
 
+func (s *TableTestSuite) TestTable_SelectQuery() {
+	tests := []struct {
+		name         string
+		queryOptions []morph.QueryOption
+		preparations func() TestModel
+		assertions   func(query string, err error)
+	}{
+		{
+			name:         "NoOptions",
+			queryOptions: []morph.QueryOption{},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
+			},
+		},
+		{
+			name:         "WithPlaceholder_NoOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", false)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
+			},
+		},
+		{
+			name:         "WithPlaceholder_WithOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", true)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
+			},
+		},
+		{
+			name:         "WithNamedParameters",
+			queryOptions: []morph.QueryOption{morph.WithNamedParameters()},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// arrange.
+			model := test.preparations()
+
+			var err error
+			s.sut, err = morph.Reflect(&model)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+
+			// action.
+			query, err := s.sut.SelectQuery(test.queryOptions...)
+
+			// assert.
+			test.assertions(query, err)
+		})
+	}
+}
+
+func (s *TableTestSuite) TestTable_MustSelectQuery_InvalidTable() {
+	// action + assert.
+	s.Panics(func() { s.sut.MustSelectQuery() })
+}
+
+func (s *TableTestSuite) TestTable_MustSelectQuery() {
+	tests := []struct {
+		name         string
+		queryOptions []morph.QueryOption
+		preparations func() TestModel
+		assertions   func(query string, err error)
+	}{
+		{
+			name:         "NoOptions",
+			queryOptions: []morph.QueryOption{},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
+			},
+		},
+		{
+			name:         "WithPlaceholder_NoOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", false)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
+			},
+		},
+		{
+			name:         "WithPlaceholder_WithOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", true)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
+			},
+		},
+		{
+			name:         "WithNamedParameters",
+			queryOptions: []morph.QueryOption{morph.WithNamedParameters()},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// arrange.
+			model := test.preparations()
+
+			var err error
+			s.sut, err = morph.Reflect(&model)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+
+			// action.
+			query := s.sut.MustSelectQuery(test.queryOptions...)
+
+			// assert.
+			test.assertions(query, err)
+		})
+	}
+}
+
+func (s *TableTestSuite) TestTable_SelectQueryWithArgs() {
+	tests := []struct {
+		name         string
+		queryOptions []morph.QueryOption
+		preparations func() TestModel
+		assertions   func(obj TestModel, query string, args []any, err error)
+	}{
+		{
+			name:         "NoOptions",
+			queryOptions: []morph.QueryOption{},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(obj TestModel, query string, args []any, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
+				s.ElementsMatch([]any{obj.ID}, args)
+			},
+		},
+		{
+			name:         "WithPlaceholder_NoOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", false)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(obj TestModel, query string, args []any, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
+				s.ElementsMatch([]any{obj.ID}, args)
+			},
+		},
+		{
+			name:         "WithPlaceholder_WithOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", true)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(obj TestModel, query string, args []any, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
+				s.ElementsMatch([]any{obj.ID}, args)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// arrange.
+			model := test.preparations()
+
+			var err error
+			s.sut, err = morph.Reflect(&model)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+
+			// action.
+			query, args, err := s.sut.SelectQueryWithArgs(model, test.queryOptions...)
+
+			// assert.
+			test.assertions(model, query, args, err)
+		})
+	}
+}
+
+func (s *TableTestSuite) TestTable_SelectQueryWithArgs_InvalidTable() {
+	// action.
+	query, args, err := s.sut.SelectQueryWithArgs(&TestModel{})
+
+	// assert.
+	s.Error(err)
+	s.Empty(query)
+	s.Empty(args)
+}
+
 func (s *TableTestSuite) TestTable_EvaluationResults_Empties() {
 	// arrange.
 	m := AnotherTestModel{


### PR DESCRIPTION
**Description**

These changes introduce query functionality that can be used to generate a `SELECT` query that retrieves a single record.

**Rationale**

While applications often have functionality that requires more complex `SELECT` queries, `morph` has the capabilities required to generate the appropriate `SELECT` query for the simple cases.

**Suggested Version**

`v1.4.0`

**Example Usage**

```go
tm := TestModel{
	ID:   1,
	Name: &name,
	Another: AnotherTestModel{
		ID:          2,
		Title:       "another",
		Description: nil,
	},
}

t, err := morph.Reflect(&model)
if err != nil {
	return err
}

// 🎉
query, args, err := t.SelectQueryWithArgs(tm)
if err != nil {
	return err
}

// 🎉
query = t.MustSelectQuery()

// 🎉
query, err = t.SelectQuery()
if err != nil {
	return err
}
```
