### PR TITLE
Introduce table reference support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,8 @@ bins:
 tests: bins
 	go test -v -race -covermode=atomic -coverprofile=morph.coverprofile
 
+coverage: tests
+	go tool cover -html=morph.coverprofile
+
 benchmarks: bins
 	go test -C internal -run XXX -bench=.

--- a/column.go
+++ b/column.go
@@ -82,3 +82,14 @@ func (c *Column) FieldType() string {
 func (c *Column) SetFieldType(fieldType string) {
 	c.fieldType = strings.TrimSpace(fieldType)
 }
+
+// equal checks if two columns are equal.
+func (c Column) equals(other Column) bool {
+	sameName := c.Name() == other.Name()
+	sameField := c.Field() == other.Field()
+	sameFieldType := c.FieldType() == other.FieldType()
+	sameFieldStrategy := c.Strategy() == other.Strategy()
+	samePrimaryKey := c.PrimaryKey() == other.PrimaryKey()
+
+	return sameName && sameField && sameFieldType && sameFieldStrategy && samePrimaryKey
+}

--- a/configuration.go
+++ b/configuration.go
@@ -9,34 +9,92 @@ type Configuration struct {
 // AsMetadata converts the configuration to metadata mappings.
 func (c Configuration) AsMetadata() []Table {
 	var tables []Table
+
+	references := map[string][]ReferenceConfiguration{}
+	tablesByName := map[string]*Table{}
+	columnsByName := map[string]*Column{}
+
 	for _, t := range c.Tables {
-		var table Table
-		table.SetTypeName(t.TypeName)
-		table.SetName(t.Name)
-		table.SetAlias(t.Alias)
-		for _, c := range t.Columns {
-			var column Column
-			column.SetField(c.Field)
-			column.SetName(c.Name)
-			column.SetFieldType(c.FieldType)
-			column.SetStrategy(c.FieldStrategy)
-			column.SetPrimaryKey(c.PrimaryKey)
-			if err := table.AddColumn(column); err != nil {
+		table := t.AsTable()
+		for _, column := range table.Columns() {
+			columnsByName[column.Name()] = &column
+		}
+		tablesByName[table.Name()] = &table
+
+		if len(t.References) > 0 {
+			if _, ok := references[table.Name()]; !ok {
+				references[table.Name()] = []ReferenceConfiguration{}
+			}
+			references[table.Name()] = append(references[table.Name()], t.References...)
+		}
+	}
+
+	for childTableName, refs := range references {
+		child, ok := tablesByName[childTableName]
+		if !ok {
+			continue
+		}
+		for _, ref := range refs {
+			parent, ok := tablesByName[ref.TableName]
+			if !ok {
+				continue
+			}
+			key := []Column{}
+			for _, fk := range ref.ForeignKey {
+				if column, ok := columnsByName[fk.ColumnName]; ok {
+					key = append(key, *column)
+				}
+			}
+			if _, err := child.References(parent, key); err != nil {
 				continue
 			}
 		}
-		tables = append(tables, table)
 	}
+
+	for _, table := range tablesByName {
+		tables = append(tables, *table)
+	}
+
 	return tables
 }
 
 // TableConfiguration represents the configuration used to construct
 // a single table mapping.
 type TableConfiguration struct {
-	TypeName string                `json:"typeName" yaml:"typeName"`
-	Name     string                `json:"name" yaml:"name"`
-	Alias    string                `json:"alias" yaml:"alias"`
-	Columns  []ColumnConfiguration `json:"columns" yaml:"columns"`
+	TypeName   string                   `json:"typeName" yaml:"typeName"`
+	Name       string                   `json:"name" yaml:"name"`
+	Alias      string                   `json:"alias" yaml:"alias"`
+	Columns    []ColumnConfiguration    `json:"columns" yaml:"columns"`
+	References []ReferenceConfiguration `json:"references" yaml:"references"`
+}
+
+// AsTable converts the configuration to a table mapping.
+func (t TableConfiguration) AsTable() Table {
+	var table Table
+	table.SetTypeName(t.TypeName)
+	table.SetName(t.Name)
+	table.SetAlias(t.Alias)
+
+	for _, c := range t.Columns {
+		if err := table.AddColumn(c.AsColumn()); err != nil {
+			continue
+		}
+	}
+
+	return table
+}
+
+// ReferenceConfiguration represents the configuration used to construct
+// a single reference between two tables.
+type ReferenceConfiguration struct {
+	TableName  string                    `json:"tableName" yaml:"tableName"`
+	ForeignKey []ForeignKeyConfiguration `json:"foreignKey" yaml:"foreignKey"`
+}
+
+// ForeignKeyConfiguration represents the configuration used to communicate
+// which columns comprise the foreign key for a reference.
+type ForeignKeyConfiguration struct {
+	ColumnName string `json:"columnName" yaml:"columnName"`
 }
 
 // ColumnConfiguration represents the configuration used to construct
@@ -47,4 +105,15 @@ type ColumnConfiguration struct {
 	FieldType     string        `json:"fieldType" yaml:"fieldType"`
 	FieldStrategy FieldStrategy `json:"fieldStrategy" yaml:"fieldStrategy"`
 	PrimaryKey    bool          `json:"primaryKey" yaml:"primaryKey"`
+}
+
+// AsColumn converts the configuration to a column mapping.
+func (c ColumnConfiguration) AsColumn() Column {
+	var column Column
+	column.SetField(c.Field)
+	column.SetName(c.Name)
+	column.SetFieldType(c.FieldType)
+	column.SetStrategy(c.FieldStrategy)
+	column.SetPrimaryKey(c.PrimaryKey)
+	return column
 }

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -130,3 +130,144 @@ func (s *ConfigurationTestSuite) TestAsMetadata() {
 	s.Require().Len(userTableConfig.References, len(businessTable.ReferencedBy()))
 	s.True(userTable.HasReferenceTo(businessTable))
 }
+
+func (s *ConfigurationTestSuite) TestAsMetadata_InvalidTableReference() {
+	// arrange.
+	config := morph.Configuration{
+		Tables: []morph.TableConfiguration{
+			{
+				TypeName: "example.User",
+				Name:     "user",
+				Alias:    "U",
+				Columns: []morph.ColumnConfiguration{
+					{
+						Name:          "username",
+						Field:         "Username",
+						FieldType:     "string",
+						FieldStrategy: morph.FieldStrategyStructField,
+						PrimaryKey:    true,
+					},
+					{
+						Name:          "business_name",
+						Field:         "BusinessName",
+						FieldType:     "string",
+						FieldStrategy: morph.FieldStrategyStructField,
+						PrimaryKey:    false,
+					},
+				},
+				References: []morph.ReferenceConfiguration{
+					{
+						TableName: "business",
+						ForeignKey: []morph.ForeignKeyConfiguration{
+							{
+								ColumnName: "business_name",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// action.
+	tables := config.AsMetadata()
+
+	// assert.
+	tablesByName := make(map[string]morph.Table)
+	for _, table := range tables {
+		tablesByName[table.Name()] = table
+	}
+
+	s.Require().Len(config.Tables, len(tables))
+
+	userTableConfig := config.Tables[0]
+	userTable := tablesByName[config.Tables[0].Name]
+
+	s.Equal(userTableConfig.TypeName, userTable.TypeName())
+	s.Equal(userTableConfig.Name, userTable.Name())
+	s.Equal(userTableConfig.Alias, userTable.Alias())
+
+	s.Require().Len(userTableConfig.Columns, len(userTable.Columns()))
+	for _, columnConfig := range userTableConfig.Columns {
+		s.Require().True(userTable.HasColumn(columnConfig.Name))
+		column := userTable.FindColumns(func(c morph.Column) bool { return c.Name() == columnConfig.Name })[0]
+		s.Equal(columnConfig.Name, column.Name())
+		s.Equal(columnConfig.Field, column.Field())
+		s.Equal(columnConfig.FieldType, column.FieldType())
+		s.True(column.UsingStructFieldStrategy())
+
+		if columnConfig.PrimaryKey {
+			s.True(column.PrimaryKey())
+		}
+	}
+
+	s.Require().Len(userTable.ReferencesTo(), 0)
+}
+
+func (s *ConfigurationTestSuite) TestAsMetadata_DuplicateColumn() {
+	// arrange.
+	config := morph.Configuration{
+		Tables: []morph.TableConfiguration{
+			{
+				TypeName: "example.User",
+				Name:     "user",
+				Alias:    "U",
+				Columns: []morph.ColumnConfiguration{
+					{
+						Name:          "username",
+						Field:         "Username",
+						FieldType:     "string",
+						FieldStrategy: morph.FieldStrategyStructField,
+						PrimaryKey:    true,
+					},
+					{
+						Name:          "business_name",
+						Field:         "BusinessName",
+						FieldType:     "string",
+						FieldStrategy: morph.FieldStrategyStructField,
+						PrimaryKey:    false,
+					},
+					{
+						Name:          "business_name",
+						Field:         "BusinessName",
+						FieldType:     "string",
+						FieldStrategy: morph.FieldStrategyStructField,
+						PrimaryKey:    false,
+					},
+				},
+			},
+		},
+	}
+
+	// action.
+	tables := config.AsMetadata()
+
+	// assert.
+	tablesByName := make(map[string]morph.Table)
+	for _, table := range tables {
+		tablesByName[table.Name()] = table
+	}
+
+	s.Require().Len(config.Tables, len(tables))
+
+	userTableConfig := config.Tables[0]
+	userTable := tablesByName[config.Tables[0].Name]
+
+	s.Equal(userTableConfig.TypeName, userTable.TypeName())
+	s.Equal(userTableConfig.Name, userTable.Name())
+	s.Equal(userTableConfig.Alias, userTable.Alias())
+
+	s.Require().Len(userTable.Columns(), len(userTableConfig.Columns)-1)
+	for _, columnConfig := range userTableConfig.Columns {
+		s.Require().True(userTable.HasColumn(columnConfig.Name))
+		column := userTable.FindColumns(func(c morph.Column) bool { return c.Name() == columnConfig.Name })[0]
+		s.Equal(columnConfig.Name, column.Name())
+		s.Equal(columnConfig.Field, column.Field())
+		s.Equal(columnConfig.FieldType, column.FieldType())
+		s.True(column.UsingStructFieldStrategy())
+
+		if columnConfig.PrimaryKey {
+			s.True(column.PrimaryKey())
+		}
+	}
+}

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -31,6 +31,44 @@ func (s *ConfigurationTestSuite) TestAsMetadata() {
 						FieldStrategy: morph.FieldStrategyStructField,
 						PrimaryKey:    true,
 					},
+					{
+						Name:          "business_name",
+						Field:         "BusinessName",
+						FieldType:     "string",
+						FieldStrategy: morph.FieldStrategyStructField,
+						PrimaryKey:    false,
+					},
+				},
+				References: []morph.ReferenceConfiguration{
+					{
+						TableName: "business",
+						ForeignKey: []morph.ForeignKeyConfiguration{
+							{
+								ColumnName: "business_name",
+							},
+						},
+					},
+				},
+			},
+			{
+				TypeName: "example.Business",
+				Name:     "business",
+				Alias:    "B",
+				Columns: []morph.ColumnConfiguration{
+					{
+						Name:          "name",
+						Field:         "Name",
+						FieldType:     "string",
+						FieldStrategy: morph.FieldStrategyStructField,
+						PrimaryKey:    true,
+					},
+					{
+						Name:          "user_count",
+						Field:         "UserCount",
+						FieldType:     "int",
+						FieldStrategy: morph.FieldStrategyStructField,
+						PrimaryKey:    false,
+					},
 				},
 			},
 		},
@@ -40,15 +78,55 @@ func (s *ConfigurationTestSuite) TestAsMetadata() {
 	tables := config.AsMetadata()
 
 	// assert.
-	s.Require().Len(config.Tables, len(tables))
-	s.Equal(config.Tables[0].TypeName, tables[0].TypeName())
-	s.Equal(config.Tables[0].Name, tables[0].Name())
-	s.Equal(config.Tables[0].Alias, tables[0].Alias())
+	tablesByName := make(map[string]morph.Table)
+	for _, table := range tables {
+		tablesByName[table.Name()] = table
+	}
 
-	s.Require().Len(config.Tables[0].Columns, len(tables[0].Columns()))
-	s.Equal(config.Tables[0].Columns[0].Name, tables[0].Columns()[0].Name())
-	s.Equal(config.Tables[0].Columns[0].Field, tables[0].Columns()[0].Field())
-	s.Equal(config.Tables[0].Columns[0].FieldType, tables[0].Columns()[0].FieldType())
-	s.True(tables[0].Columns()[0].UsingStructFieldStrategy())
-	s.Equal(config.Tables[0].Columns[0].PrimaryKey, tables[0].Columns()[0].PrimaryKey())
+	s.Require().Len(config.Tables, len(tables))
+
+	userTableConfig := config.Tables[0]
+	businessTableConfig := config.Tables[1]
+	userTable := tablesByName[config.Tables[0].Name]
+	businessTable := tablesByName[config.Tables[1].Name]
+
+	s.Equal(userTableConfig.TypeName, userTable.TypeName())
+	s.Equal(userTableConfig.Name, userTable.Name())
+	s.Equal(userTableConfig.Alias, userTable.Alias())
+
+	s.Equal(businessTableConfig.TypeName, businessTable.TypeName())
+	s.Equal(businessTableConfig.Name, businessTable.Name())
+	s.Equal(businessTableConfig.Alias, businessTable.Alias())
+
+	s.Require().Len(userTableConfig.Columns, len(userTable.Columns()))
+	for _, columnConfig := range userTableConfig.Columns {
+		s.Require().True(userTable.HasColumn(columnConfig.Name))
+		column := userTable.FindColumns(func(c morph.Column) bool { return c.Name() == columnConfig.Name })[0]
+		s.Equal(columnConfig.Name, column.Name())
+		s.Equal(columnConfig.Field, column.Field())
+		s.Equal(columnConfig.FieldType, column.FieldType())
+		s.True(column.UsingStructFieldStrategy())
+
+		if columnConfig.PrimaryKey {
+			s.True(column.PrimaryKey())
+		}
+	}
+
+	for _, columnConfig := range businessTableConfig.Columns {
+		s.Require().True(businessTable.HasColumn(columnConfig.Name))
+		column := businessTable.FindColumns(func(c morph.Column) bool { return c.Name() == columnConfig.Name })[0]
+		s.Equal(columnConfig.Name, column.Name())
+		s.Equal(columnConfig.Field, column.Field())
+		s.Equal(columnConfig.FieldType, column.FieldType())
+		s.True(column.UsingStructFieldStrategy())
+
+		if columnConfig.PrimaryKey {
+			s.True(column.PrimaryKey())
+		}
+	}
+
+	s.Require().Len(userTableConfig.References, len(userTable.ReferencesTo()))
+	s.True(businessTable.IsReferencedBy(userTable))
+	s.Require().Len(userTableConfig.References, len(businessTable.ReferencedBy()))
+	s.True(userTable.HasReferenceTo(businessTable))
 }

--- a/internal/benchmark_test.go
+++ b/internal/benchmark_test.go
@@ -16,6 +16,13 @@ type Starship struct {
 	Crew       int     `morph:"crew_capacity"`
 	Speed      float64 `morph:"max_speed"`
 	SpeedUnit  string  `morph:"speed_unit"`
+	Owners     []Owner
+}
+
+type Owner struct {
+	ID         int    `morph:"id"`
+	Name       string `morph:"name"`
+	StarshipID int    `morph:"starship_id"`
 }
 
 var (
@@ -29,6 +36,28 @@ var (
 		Crew:       4,
 		Speed:      1050,
 		SpeedUnit:  "km/h",
+		Owners: []Owner{
+			{
+				ID:         1,
+				Name:       "Han Solo",
+				StarshipID: 1,
+			},
+			{
+				ID:         2,
+				Name:       "Chewbacca",
+				StarshipID: 1,
+			},
+			{
+				ID:         3,
+				Name:       "Lando Calrissian",
+				StarshipID: 1,
+			},
+			{
+				ID:         4,
+				Name:       "Nien Nunb",
+				StarshipID: 1,
+			},
+		},
 	}
 )
 
@@ -596,6 +625,608 @@ func BenchmarkTableSelectQueryWithArgs_WithNamedParameters(b *testing.B) {
 
 	for b.Loop() {
 		_, _, err := table.SelectQueryWithArgs(millenniumFalcon, morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+//
+
+func BenchmarkReferenceInsertQueryWithArgs_DefaultOptions(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, _, err := ref.InsertQueryWithArgs(millenniumFalcon.Owners[0])
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceInsertQueryWithArgs_WithPlaceholder(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, _, err := ref.InsertQueryWithArgs(millenniumFalcon.Owners[0], morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceInsertQueryWithArgs_WithNamedParameters(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, _, err := ref.InsertQueryWithArgs(millenniumFalcon.Owners[0], morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceUpdateQueryWithArgs_DefaultOptions(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, _, err := ref.UpdateQueryWithArgs(millenniumFalcon.Owners[0])
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceUpdateQueryWithArgs_WithPlaceholder(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, _, err := ref.UpdateQueryWithArgs(millenniumFalcon.Owners[0], morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceUpdateQueryWithArgs_WithNamedParameters(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, _, err := ref.UpdateQueryWithArgs(millenniumFalcon.Owners[0], morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceUpdateQueryWithArgs_WithoutEmptyValues(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, _, err := ref.UpdateQueryWithArgs(millenniumFalcon.Owners[0], morph.WithoutEmptyValues(millenniumFalcon.Owners[0]))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceDeleteQueryWithArgs_DefaultOptions(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, _, err := ref.DeleteQueryWithArgs(millenniumFalcon.Owners[0])
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceDeleteQueryWithArgs_WithPlaceholder(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, _, err := ref.DeleteQueryWithArgs(millenniumFalcon.Owners[0], morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceDeleteQueryWithArgs_WithNamedParameters(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, _, err := ref.DeleteQueryWithArgs(millenniumFalcon.Owners[0], morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceSelectQueryWithArgs_DefaultOptions(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, _, err := ref.SelectQueryWithArgs(millenniumFalcon.Owners[0])
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceSelectQueryWithArgs_WithPlaceholder(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, _, err := ref.SelectQueryWithArgs(millenniumFalcon.Owners[0], morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceSelectQueryWithArgs_WithNamedParameters(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, _, err := ref.SelectQueryWithArgs(millenniumFalcon.Owners[0], morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+//
+
+func BenchmarkReferenceInsertQuery_DefaultOptions(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, err := ref.InsertQuery()
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceInsertQuery_WithPlaceholder(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, err := ref.InsertQuery(morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceInsertQuery_WithNamedParameters(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, err := ref.InsertQuery(morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceUpdateQuery_DefaultOptions(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, err := ref.UpdateQuery()
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceUpdateQuery_WithPlaceholder(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, err := ref.UpdateQuery(morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceUpdateQuery_WithNamedParameters(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, err := ref.UpdateQuery(morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceUpdateQuery_WithoutEmptyValues(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, err := ref.UpdateQuery(morph.WithoutEmptyValues(millenniumFalcon.Owners[0]))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceDeleteQuery_DefaultOptions(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, err := ref.DeleteQuery()
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceDeleteQuery_WithPlaceholder(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, err := ref.DeleteQuery(morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceDeleteQuery_WithNamedParameters(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, err := ref.DeleteQuery(morph.WithNamedParameters())
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceSelectQuery_DefaultOptions(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, err := ref.SelectQuery()
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceSelectQuery_WithPlaceholder(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, err := ref.SelectQuery(morph.WithPlaceholder("$", true))
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReferenceSelectQuery_WithNamedParameters(b *testing.B) {
+	parent, err := morph.Reflect(millenniumFalcon)
+	if err != nil {
+		b.FailNow()
+	}
+
+	child, err := morph.Reflect(millenniumFalcon.Owners[0])
+	if err != nil {
+		b.FailNow()
+	}
+
+	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
+		return c.Name() == "starship_id"
+	}))
+
+	for b.Loop() {
+		_, err := ref.SelectQuery(morph.WithNamedParameters())
 		if err != nil {
 			b.FailNow()
 		}

--- a/internal/benchmark_test.go
+++ b/internal/benchmark_test.go
@@ -647,6 +647,9 @@ func BenchmarkReferenceInsertQueryWithArgs_DefaultOptions(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, _, err := ref.InsertQueryWithArgs(millenniumFalcon.Owners[0])
@@ -670,6 +673,9 @@ func BenchmarkReferenceInsertQueryWithArgs_WithPlaceholder(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, _, err := ref.InsertQueryWithArgs(millenniumFalcon.Owners[0], morph.WithPlaceholder("$", true))
@@ -693,6 +699,9 @@ func BenchmarkReferenceInsertQueryWithArgs_WithNamedParameters(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, _, err := ref.InsertQueryWithArgs(millenniumFalcon.Owners[0], morph.WithNamedParameters())
@@ -716,6 +725,9 @@ func BenchmarkReferenceUpdateQueryWithArgs_DefaultOptions(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, _, err := ref.UpdateQueryWithArgs(millenniumFalcon.Owners[0])
@@ -739,6 +751,9 @@ func BenchmarkReferenceUpdateQueryWithArgs_WithPlaceholder(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, _, err := ref.UpdateQueryWithArgs(millenniumFalcon.Owners[0], morph.WithPlaceholder("$", true))
@@ -762,6 +777,9 @@ func BenchmarkReferenceUpdateQueryWithArgs_WithNamedParameters(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, _, err := ref.UpdateQueryWithArgs(millenniumFalcon.Owners[0], morph.WithNamedParameters())
@@ -785,6 +803,9 @@ func BenchmarkReferenceUpdateQueryWithArgs_WithoutEmptyValues(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, _, err := ref.UpdateQueryWithArgs(millenniumFalcon.Owners[0], morph.WithoutEmptyValues(millenniumFalcon.Owners[0]))
@@ -808,6 +829,9 @@ func BenchmarkReferenceDeleteQueryWithArgs_DefaultOptions(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, _, err := ref.DeleteQueryWithArgs(millenniumFalcon.Owners[0])
@@ -831,6 +855,9 @@ func BenchmarkReferenceDeleteQueryWithArgs_WithPlaceholder(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, _, err := ref.DeleteQueryWithArgs(millenniumFalcon.Owners[0], morph.WithPlaceholder("$", true))
@@ -854,6 +881,9 @@ func BenchmarkReferenceDeleteQueryWithArgs_WithNamedParameters(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, _, err := ref.DeleteQueryWithArgs(millenniumFalcon.Owners[0], morph.WithNamedParameters())
@@ -877,6 +907,9 @@ func BenchmarkReferenceSelectQueryWithArgs_DefaultOptions(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, _, err := ref.SelectQueryWithArgs(millenniumFalcon.Owners[0])
@@ -900,6 +933,9 @@ func BenchmarkReferenceSelectQueryWithArgs_WithPlaceholder(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, _, err := ref.SelectQueryWithArgs(millenniumFalcon.Owners[0], morph.WithPlaceholder("$", true))
@@ -923,6 +959,9 @@ func BenchmarkReferenceSelectQueryWithArgs_WithNamedParameters(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, _, err := ref.SelectQueryWithArgs(millenniumFalcon.Owners[0], morph.WithNamedParameters())
@@ -948,6 +987,9 @@ func BenchmarkReferenceInsertQuery_DefaultOptions(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, err := ref.InsertQuery()
@@ -971,6 +1013,9 @@ func BenchmarkReferenceInsertQuery_WithPlaceholder(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, err := ref.InsertQuery(morph.WithPlaceholder("$", true))
@@ -994,6 +1039,9 @@ func BenchmarkReferenceInsertQuery_WithNamedParameters(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, err := ref.InsertQuery(morph.WithNamedParameters())
@@ -1017,6 +1065,9 @@ func BenchmarkReferenceUpdateQuery_DefaultOptions(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, err := ref.UpdateQuery()
@@ -1040,6 +1091,9 @@ func BenchmarkReferenceUpdateQuery_WithPlaceholder(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, err := ref.UpdateQuery(morph.WithPlaceholder("$", true))
@@ -1063,6 +1117,9 @@ func BenchmarkReferenceUpdateQuery_WithNamedParameters(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, err := ref.UpdateQuery(morph.WithNamedParameters())
@@ -1086,6 +1143,9 @@ func BenchmarkReferenceUpdateQuery_WithoutEmptyValues(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, err := ref.UpdateQuery(morph.WithoutEmptyValues(millenniumFalcon.Owners[0]))
@@ -1109,6 +1169,9 @@ func BenchmarkReferenceDeleteQuery_DefaultOptions(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, err := ref.DeleteQuery()
@@ -1132,6 +1195,9 @@ func BenchmarkReferenceDeleteQuery_WithPlaceholder(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, err := ref.DeleteQuery(morph.WithPlaceholder("$", true))
@@ -1155,6 +1221,9 @@ func BenchmarkReferenceDeleteQuery_WithNamedParameters(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, err := ref.DeleteQuery(morph.WithNamedParameters())
@@ -1178,6 +1247,9 @@ func BenchmarkReferenceSelectQuery_DefaultOptions(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, err := ref.SelectQuery()
@@ -1201,6 +1273,9 @@ func BenchmarkReferenceSelectQuery_WithPlaceholder(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, err := ref.SelectQuery(morph.WithPlaceholder("$", true))
@@ -1224,6 +1299,9 @@ func BenchmarkReferenceSelectQuery_WithNamedParameters(b *testing.B) {
 	ref, err := child.References(&parent, child.FindColumns(func(c morph.Column) bool {
 		return c.Name() == "starship_id"
 	}))
+	if err != nil {
+		b.FailNow()
+	}
 
 	for b.Loop() {
 		_, err := ref.SelectQuery(morph.WithNamedParameters())

--- a/query.go
+++ b/query.go
@@ -76,7 +76,7 @@ const updateSQL = `
   {{- $options := .Options -}}
   {{- $seq := 0 -}}
   {{- $data := .Data -}}
-  {{- $nonPrimaryKeys := .NonPrimaryKeys -}}
+  {{- $nonPrimaryKeys := .NonKeys -}}
   UPDATE {{$table.Name}} AS {{$table.Alias}} SET {{- if true}} {{end}}
   {{- range $idx, $col := $nonPrimaryKeys -}}
     {{- if omit $data $col.Name -}} {{continue}} {{- end -}}
@@ -84,7 +84,7 @@ const updateSQL = `
     {{- $seq = add $seq 1 -}}
     {{$table.Alias}}.{{.Name}} = {{param $col.Name $options $seq}}
   {{- end }} WHERE 1=1
-  {{- range $idx, $col := .PrimaryKeys -}}
+  {{- range $idx, $col := .Key -}}
     {{- $seq = add $seq 1 }} AND {{$table.Alias}}.{{.Name}} = {{param $col.Name $options $seq}}
   {{- end -}};`
 
@@ -94,7 +94,7 @@ const deleteSQL = `
   {{- $options := .Options -}}
   {{- $seq := 0 -}}
   DELETE FROM {{$table.Name}} WHERE 1=1
-  {{- range $idx, $col := .PrimaryKeys -}}
+  {{- range $idx, $col := .Key -}}
     {{- $seq = add $seq 1 }} AND {{.Name}} = {{param $col.Name $options $seq}}
   {{- end -}};`
 
@@ -107,7 +107,7 @@ const selectSQL = `
     {{$col.Name}}{{if ne $idx (sub (len $table.Columns) 1)}}, {{end}}
   {{- end -}}
   {{- if true}} {{end -}} FROM {{$table.Name}} AS {{$table.Alias}} WHERE 1=1
-  {{- range $idx, $col := .PrimaryKeys -}}
+  {{- range $idx, $col := .Key -}}
     {{- $seq = add $seq 1 }} AND {{$table.Alias}}.{{.Name}} = {{param $col.Name $options $seq}}
   {{- end -}};`
 

--- a/query_generator.go
+++ b/query_generator.go
@@ -1,0 +1,169 @@
+package morph
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+type queryGenerator struct {
+	table         *Table
+	keyColumns    []Column
+	nonKeyColumns []Column
+}
+
+// newQueryGenerator creates a new query generator for the given table.
+func newQueryGenerator(table *Table, keyColumns, nonKeyColumns []Column) queryGenerator {
+	return queryGenerator{
+		table:         table,
+		keyColumns:    keyColumns,
+		nonKeyColumns: nonKeyColumns,
+	}
+}
+
+// query generates a query for the table using the provided template and options.
+func (generator *queryGenerator) query(tmpl *template.Template, options ...QueryOption) (string, error) {
+	if err := generator.table.validate(); err != nil {
+		return "", err
+	}
+
+	qo := &QueryOptions{}
+	opts := append(DefaultQueryOptions, options...)
+	for _, opt := range opts {
+		opt(qo)
+	}
+
+	data := struct {
+		Table   *Table
+		Key     []Column
+		NonKeys []Column
+		Options *QueryOptions
+		Data    EvaluationResult
+	}{
+		Table:   generator.table,
+		Options: qo,
+		Key:     generator.keyColumns,
+		NonKeys: generator.nonKeyColumns,
+	}
+
+	if qo.OmitEmpty && qo.obj != nil {
+		var err error
+		if data.Data, err = generator.table.Evaluate(qo.obj); err != nil {
+			return "", err
+		}
+	}
+
+	buf := new(bytes.Buffer)
+	err := tmpl.Execute(buf, data)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func (generator *queryGenerator) queryWithArgs(namedQuery string, obj any, options ...QueryOption) (string, []any, error) {
+	qo := &QueryOptions{}
+	opts := append(DefaultQueryOptions, options...)
+	for _, opt := range opts {
+		opt(qo)
+	}
+
+	result, err := generator.table.Evaluate(obj)
+	if err != nil {
+		return "", nil, err
+	}
+
+	args := []any{}
+	missing := []string{}
+
+	count := 0
+	query := namedParamRegExp.ReplaceAllStringFunc(namedQuery, func(match string) string {
+		name := match[1:]
+
+		if arg, ok := result[name]; ok {
+			args = append(args, arg)
+			if qo.Ordered {
+				count += 1
+				return qo.Placeholder + fmt.Sprintf("%d", count)
+			}
+			return qo.Placeholder
+		}
+
+		missing = append(missing, name)
+		return match
+	})
+
+	if len(missing) > 0 {
+		return "", nil, errors.New("morph: missing values for named parameters: " + strings.Join(missing, ", "))
+	}
+
+	return query, args, nil
+}
+
+// InsertQuery generates an INSERT query for the table.
+func (generator queryGenerator) InsertQuery(options ...QueryOption) (string, error) {
+	return generator.query(insertTmpl, options...)
+}
+
+// InsertQueryWithArgs generates an INSERT query for the table along with arguments
+// derived from the provided object.
+func (generator queryGenerator) InsertQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
+	opts := append(options, WithNamedParameters())
+	query, err := generator.InsertQuery(opts...)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return generator.queryWithArgs(query, obj, opts...)
+}
+
+// SelectQuery generates a SELECT query for the table.
+func (generator queryGenerator) SelectQuery(options ...QueryOption) (string, error) {
+	return generator.query(selectTmpl, options...)
+}
+
+// SelectQueryWithArgs generates a SELECT query for the table along with arguments
+// derived from the provided object.
+func (generator *queryGenerator) SelectQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
+	query, err := generator.SelectQuery(options...)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return generator.queryWithArgs(query, obj, options...)
+}
+
+// UpdateQuery generates an UPDATE query for the table.
+func (generator queryGenerator) UpdateQuery(options ...QueryOption) (string, error) {
+	return generator.query(updateTmpl, options...)
+}
+
+// UpdateQueryWithArgs generates an UPDATE query for the table along with arguments
+// derived from the provided object.
+func (generator *queryGenerator) UpdateQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
+	query, err := generator.UpdateQuery(options...)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return generator.queryWithArgs(query, obj, options...)
+}
+
+// DeleteQueryWithArgs generates a DELETE query for the table along with arguments
+// derived from the provided object.
+func (generator *queryGenerator) DeleteQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
+	query, err := generator.DeleteQuery(options...)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return generator.queryWithArgs(query, obj, options...)
+}
+
+// DeleteQuery generates a DELETE query for the table.
+func (generator queryGenerator) DeleteQuery(options ...QueryOption) (string, error) {
+	return generator.query(deleteTmpl, options...)
+}

--- a/reference.go
+++ b/reference.go
@@ -1,0 +1,153 @@
+package morph
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"text/template"
+)
+
+// Reference represents a reference between two tables via a foreign key.
+type Reference struct {
+	parent     Table
+	child      Table
+	foreignKey []Column
+}
+
+// Parent returns the parent table of the reference.
+func (r *Reference) Parent() Table {
+	return r.parent
+}
+
+// Child returns the child table of the reference.
+func (r *Reference) Child() Table {
+	return r.child
+}
+
+// ForeignKey returns the foreign key columns of the reference.
+func (r *Reference) ForeignKey() []Column {
+	key := make([]Column, len(r.foreignKey))
+	copy(key, r.foreignKey)
+	return key
+}
+
+// equal checks if two references are equal.
+func (r Reference) equals(other Reference) bool {
+	sameParent := r.Parent().Equals(other.Parent())
+	sameChild := r.Child().Equals(other.Child())
+	sameForeignKey := slices.EqualFunc(r.ForeignKey(), other.ForeignKey(), func(a, b Column) bool {
+		return a.equals(b)
+	})
+
+	return sameParent && sameChild && sameForeignKey
+}
+
+// query generates a query for the table using the provided template and options.
+func (r *Reference) query(tmpl *template.Template, options ...QueryOption) (string, error) {
+	qo := &QueryOptions{}
+	opts := append(DefaultQueryOptions, options...)
+	for _, opt := range opts {
+		opt(qo)
+	}
+
+	data := struct {
+		Table   *Table
+		Key     []Column
+		NonKeys []Column
+		Options *QueryOptions
+		Data    EvaluationResult
+	}{
+		Table:   &r.child,
+		Options: qo,
+		Key:     r.foreignKey,
+		NonKeys: r.child.FindColumns(func(c Column) bool { return !c.PrimaryKey() }),
+	}
+
+	if qo.OmitEmpty && qo.obj != nil {
+		var err error
+		if data.Data, err = r.child.Evaluate(qo.obj); err != nil {
+			return "", err
+		}
+	}
+
+	buf := new(bytes.Buffer)
+	err := tmpl.Execute(buf, data)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func (r *Reference) queryWithArgs(namedQuery string, obj any, options ...QueryOption) (string, []any, error) {
+	qo := &QueryOptions{}
+	opts := append(DefaultQueryOptions, options...)
+	for _, opt := range opts {
+		opt(qo)
+	}
+
+	result, err := r.child.Evaluate(obj)
+	if err != nil {
+		return "", nil, err
+	}
+
+	args := []any{}
+	missing := []string{}
+
+	count := 0
+	query := namedParamRegExp.ReplaceAllStringFunc(namedQuery, func(match string) string {
+		name := match[1:]
+
+		if arg, ok := result[name]; ok {
+			args = append(args, arg)
+			if qo.Ordered {
+				count += 1
+				return qo.Placeholder + fmt.Sprintf("%d", count)
+			}
+			return qo.Placeholder
+		}
+
+		missing = append(missing, name)
+		return match
+	})
+
+	if len(missing) > 0 {
+		return "", nil, errors.New("morph: missing values for named parameters: " + strings.Join(missing, ", "))
+	}
+
+	return query, args, nil
+}
+
+// SelectQuery generates a SELECT query for the reference.
+func (r *Reference) SelectQuery(options ...QueryOption) (string, error) {
+	return r.query(selectTmpl, options...)
+}
+
+// SelectQueryWithArgs generates a SELECT query with arguments for the reference.
+func (r *Reference) SelectQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
+	opts := append(options, WithNamedParameters())
+	query, err := r.SelectQuery(opts...)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return r.queryWithArgs(query, obj, opts...)
+}
+
+// DeleteQuery generates a DELETE query for the reference.
+func (r *Reference) DeleteQuery(options ...QueryOption) (string, error) {
+	return r.query(deleteTmpl, options...)
+}
+
+// DeleteQueryWithArgs generates a DELETE query with arguments for the reference.
+func (r *Reference) DeleteQueryWithArgs(obj any, options ...QueryOption) (string, []any, error) {
+	opts := append(options, WithNamedParameters())
+	query, err := r.DeleteQuery(opts...)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return r.queryWithArgs(query, obj, opts...)
+}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -33,6 +33,7 @@ type AnotherTestModel struct {
 	Title       string
 	Description *string
 	secret      string
+	ModelID     int // foreign key
 }
 
 type ReflectTestSuite struct {
@@ -55,6 +56,7 @@ func (s *ReflectTestSuite) SetupTest() {
 			ID:          2,
 			Title:       "another",
 			Description: nil,
+			ModelID:     1,
 			secret:      "shhh!",
 		},
 	}

--- a/table.go
+++ b/table.go
@@ -523,7 +523,7 @@ func (t *Table) MustSelectQuery(options ...QueryOption) string {
 
 // References creates a reference between two tables, where the provided table
 // is treated as the parent and the current table is treated as the child.
-func (t *Table) References(table *Table, key ...Column) (Reference, error) {
+func (t *Table) References(table *Table, key []Column) (Reference, error) {
 	if err := t.validate(); err != nil {
 		return Reference{}, err
 	}
@@ -549,7 +549,7 @@ func (t *Table) References(table *Table, key ...Column) (Reference, error) {
 	return Reference{parent: *table, child: *t, foreignKey: key}, nil
 }
 
-// equal checks if two tables are equal.
+// Equals checks if two tables are equal.
 func (t Table) Equals(other Table) bool {
 	sameTypeName := t.TypeName() == other.TypeName()
 	sameName := t.Name() == other.Name()

--- a/table.go
+++ b/table.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"text/template"
 	"time"
 )
 

--- a/table.go
+++ b/table.go
@@ -242,6 +242,15 @@ func (t *Table) NonPrimaryKeyColumns() []Column {
 	})
 }
 
+// HasColumn indicates whether the table has a column with the provided name.
+func (t *Table) HasColumn(name string) bool {
+	if t.columnsByName == nil {
+		t.columnsByName = make(map[string]Column)
+	}
+	_, ok := t.columnsByName[name]
+	return ok
+}
+
 // ColumnName retrieves the column name associated to the provide field name.
 func (t *Table) ColumnName(field string) (string, error) {
 	if t.columnsByField == nil {

--- a/table_example_test.go
+++ b/table_example_test.go
@@ -1,0 +1,427 @@
+package morph_test
+
+import (
+	"fmt"
+
+	"github.com/freerware/morph"
+)
+
+type Starship struct {
+	ID         int     `morph:"id"`
+	Name       string  `morph:"ship_name"`
+	Category   string  `morph:"category"`
+	Class      string  `morph:"class"`
+	Length     float64 `morph:"length"`
+	LengthUnit string  `morph:"length_unit"`
+	Crew       int     `morph:"crew_capacity"`
+	Speed      float64 `morph:"max_speed"`
+	SpeedUnit  string  `morph:"speed_unit"`
+}
+
+func ExampleTable_SelectQueryWithArgs_noOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, args, err := table.SelectQueryWithArgs(mf)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	fmt.Println(args)
+	// Output:
+	// SELECT category, class, crew, id, length, length_unit, name, speed, speed_unit FROM starships AS S WHERE 1=1 AND S.id = ?;
+	// [1]
+}
+
+func ExampleTable_SelectQueryWithArgs_withOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, args, err := table.SelectQueryWithArgs(mf, morph.WithPlaceholder("$", true))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	fmt.Println(args)
+	// Output:
+	// SELECT category, class, crew, id, length, length_unit, name, speed, speed_unit FROM starships AS S WHERE 1=1 AND S.id = $1;
+	// [1]
+}
+
+func ExampleTable_SelectQuery_noOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, err := table.SelectQuery()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	// Output: SELECT category, class, crew, id, length, length_unit, name, speed, speed_unit FROM starships AS S WHERE 1=1 AND S.id = ?;
+}
+
+func ExampleTable_SelectQuery_withOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, err := table.SelectQuery(morph.WithPlaceholder("$", true))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	// Output: SELECT category, class, crew, id, length, length_unit, name, speed, speed_unit FROM starships AS S WHERE 1=1 AND S.id = $1;
+}
+
+func ExampleTable_UpdateQueryWithArgs_noOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, args, err := table.UpdateQueryWithArgs(mf)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	fmt.Println(args)
+	// Output:
+	// UPDATE starships AS S SET S.category = ?, S.class = ?, S.crew = ?, S.length = ?, S.length_unit = ?, S.name = ?, S.speed = ?, S.speed_unit = ? WHERE 1=1 AND S.id = ?;
+	// [Light Freighter Yacht 4 34.75 m Millennium Falcon 1050 km/h 1]
+}
+
+func ExampleTable_UpdateQueryWithArgs_withOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, args, err := table.UpdateQueryWithArgs(mf, morph.WithPlaceholder("$", true))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	fmt.Println(args)
+	// Output:
+	// UPDATE starships AS S SET S.category = $1, S.class = $2, S.crew = $3, S.length = $4, S.length_unit = $5, S.name = $6, S.speed = $7, S.speed_unit = $8 WHERE 1=1 AND S.id = $9;
+	// [Light Freighter Yacht 4 34.75 m Millennium Falcon 1050 km/h 1]
+}
+
+func ExampleTable_UpdateQuery_noOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, err := table.UpdateQuery()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	// Output: UPDATE starships AS S SET S.category = ?, S.class = ?, S.crew = ?, S.length = ?, S.length_unit = ?, S.name = ?, S.speed = ?, S.speed_unit = ? WHERE 1=1 AND S.id = ?;
+}
+
+func ExampleTable_UpdateQuery_withOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, err := table.UpdateQuery(morph.WithPlaceholder("$", true))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	// Output: UPDATE starships AS S SET S.category = $1, S.class = $2, S.crew = $3, S.length = $4, S.length_unit = $5, S.name = $6, S.speed = $7, S.speed_unit = $8 WHERE 1=1 AND S.id = $9;
+}
+
+func ExampleTable_DeleteQueryWithArgs_noOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, args, err := table.DeleteQueryWithArgs(mf)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	fmt.Println(args)
+	// Output:
+	// DELETE FROM starships WHERE 1=1 AND id = ?;
+	// [1]
+}
+
+func ExampleTable_DeleteQueryWithArgs_withOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, args, err := table.DeleteQueryWithArgs(mf, morph.WithPlaceholder("$", true))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	fmt.Println(args)
+	// Output:
+	// DELETE FROM starships WHERE 1=1 AND id = $1;
+	// [1]
+}
+
+func ExampleTable_DeleteQuery_noOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, err := table.DeleteQuery()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	// Output: DELETE FROM starships WHERE 1=1 AND id = ?;
+}
+
+func ExampleTable_DeleteQuery_withOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, err := table.DeleteQuery(morph.WithPlaceholder("$", true))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	// Output: DELETE FROM starships WHERE 1=1 AND id = $1;
+}
+
+func ExampleTable_InsertQueryWithArgs_noOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, args, err := table.InsertQueryWithArgs(mf)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	fmt.Println(args)
+	// Output:
+	// INSERT INTO starships (category, class, crew, id, length, length_unit, name, speed, speed_unit) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+	// [Light Freighter Yacht 4 1 34.75 m Millennium Falcon 1050 km/h]
+}
+
+func ExampleTable_InsertQueryWithArgs_withOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, args, err := table.InsertQueryWithArgs(mf, morph.WithPlaceholder("$", true))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	fmt.Println(args)
+	// Output:
+	// INSERT INTO starships (category, class, crew, id, length, length_unit, name, speed, speed_unit) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);
+	// [Light Freighter Yacht 4 1 34.75 m Millennium Falcon 1050 km/h]
+}
+
+func ExampleTable_InsertQuery_noOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, err := table.InsertQuery()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	// Output: INSERT INTO starships (category, class, crew, id, length, length_unit, name, speed, speed_unit) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+}
+
+func ExampleTable_InsertQuery_withOptions() {
+	mf := Starship{
+		ID:         1,
+		Name:       "Millennium Falcon",
+		Category:   "Light Freighter",
+		Class:      "Yacht",
+		Length:     34.75,
+		LengthUnit: "m",
+		Crew:       4,
+		Speed:      1050,
+		SpeedUnit:  "km/h",
+	}
+
+	table := morph.Must(morph.Reflect(mf))
+
+	query, err := table.InsertQuery(morph.WithPlaceholder("$", true))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(query)
+	// Output: INSERT INTO starships (category, class, crew, id, length, length_unit, name, speed, speed_unit) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);
+}

--- a/table_example_test.go
+++ b/table_example_test.go
@@ -41,7 +41,7 @@ func ExampleTable_SelectQueryWithArgs_noOptions() {
 	fmt.Println(query)
 	fmt.Println(args)
 	// Output:
-	// SELECT category, class, crew, id, length, length_unit, name, speed, speed_unit FROM starships AS S WHERE 1=1 AND S.id = ?;
+	// SELECT S.category, S.class, S.crew, S.id, S.length, S.length_unit, S.name, S.speed, S.speed_unit FROM starships AS S WHERE 1=1 AND S.id = ?;
 	// [1]
 }
 
@@ -68,7 +68,7 @@ func ExampleTable_SelectQueryWithArgs_withOptions() {
 	fmt.Println(query)
 	fmt.Println(args)
 	// Output:
-	// SELECT category, class, crew, id, length, length_unit, name, speed, speed_unit FROM starships AS S WHERE 1=1 AND S.id = $1;
+	// SELECT S.category, S.class, S.crew, S.id, S.length, S.length_unit, S.name, S.speed, S.speed_unit FROM starships AS S WHERE 1=1 AND S.id = $1;
 	// [1]
 }
 
@@ -93,7 +93,7 @@ func ExampleTable_SelectQuery_noOptions() {
 	}
 
 	fmt.Println(query)
-	// Output: SELECT category, class, crew, id, length, length_unit, name, speed, speed_unit FROM starships AS S WHERE 1=1 AND S.id = ?;
+	// Output: SELECT S.category, S.class, S.crew, S.id, S.length, S.length_unit, S.name, S.speed, S.speed_unit FROM starships AS S WHERE 1=1 AND S.id = ?;
 }
 
 func ExampleTable_SelectQuery_withOptions() {
@@ -117,7 +117,7 @@ func ExampleTable_SelectQuery_withOptions() {
 	}
 
 	fmt.Println(query)
-	// Output: SELECT category, class, crew, id, length, length_unit, name, speed, speed_unit FROM starships AS S WHERE 1=1 AND S.id = $1;
+	// Output: SELECT S.category, S.class, S.crew, S.id, S.length, S.length_unit, S.name, S.speed, S.speed_unit FROM starships AS S WHERE 1=1 AND S.id = $1;
 }
 
 func ExampleTable_UpdateQueryWithArgs_noOptions() {

--- a/table_test.go
+++ b/table_test.go
@@ -50,7 +50,7 @@ func (s *TableTestSuite) TestTable_References_InvalidChildTable() {
 	var child morph.Table
 
 	// action.
-	ref, err := child.References(&s.sut)
+	ref, err := child.References(&s.sut, []morph.Column{})
 
 	// assert.
 	s.Require().Error(err)
@@ -79,7 +79,7 @@ func (s *TableTestSuite) TestTable_References_InvalidParentTable() {
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
 
 	// action.
-	ref, err := child.References(&s.sut, key...)
+	ref, err := child.References(&s.sut, key)
 
 	// assert.
 	s.Require().Error(err)
@@ -118,7 +118,7 @@ func (s *TableTestSuite) TestTable_References_MissingForeignKeyColumns() {
 	usernameColumn.SetName(usernameColumnName)
 
 	// action.
-	ref, err := child.References(&s.sut, []morph.Column{usernameColumn}...)
+	ref, err := child.References(&s.sut, []morph.Column{usernameColumn})
 
 	// assert.
 	s.Require().Error(err)
@@ -151,10 +151,10 @@ func (s *TableTestSuite) TestTable_References_EnforcesUniqueness() {
 	}
 
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-	if _, err := child.References(&s.sut, key...); err != nil {
+	if _, err := child.References(&s.sut, key); err != nil {
 		s.FailNow("unable to establish reference to table", err)
 	}
-	if _, err := child.References(&s.sut, key...); err != nil {
+	if _, err := child.References(&s.sut, key); err != nil {
 		s.FailNow("unable to establish reference to table", err)
 	}
 
@@ -192,7 +192,7 @@ func (s *TableTestSuite) TestTable_IsReferenced_WithReference() {
 	}
 
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-	if _, err := child.References(&s.sut, key...); err != nil {
+	if _, err := child.References(&s.sut, key); err != nil {
 		s.FailNow("unable to establish reference to table", err)
 	}
 
@@ -256,7 +256,7 @@ func (s *TableTestSuite) TestTable_ReferenceTo_WithReference() {
 	}
 
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-	if _, err := child.References(&s.sut, key...); err != nil {
+	if _, err := child.References(&s.sut, key); err != nil {
 		s.FailNow("unable to establish reference to table", err)
 	}
 
@@ -329,7 +329,7 @@ func (s *TableTestSuite) TestTable_HasReferenceTo_WithReference() {
 	}
 
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-	if _, err := child.References(&s.sut, key...); err != nil {
+	if _, err := child.References(&s.sut, key); err != nil {
 		s.FailNow("unable to establish reference to table", err)
 	}
 
@@ -398,7 +398,7 @@ func (s *TableTestSuite) TestTable_ReferencesTo_WithReferences() {
 	}
 
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-	if _, err := child.References(&s.sut, key...); err != nil {
+	if _, err := child.References(&s.sut, key); err != nil {
 		s.FailNow("unable to establish reference to table", err)
 	}
 
@@ -468,7 +468,7 @@ func (s *TableTestSuite) TestTable_ReferencedBy_WithReferences() {
 	}
 
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-	if _, err := child.References(&s.sut, key...); err != nil {
+	if _, err := child.References(&s.sut, key); err != nil {
 		s.FailNow("unable to establish reference to table", err)
 	}
 
@@ -533,7 +533,7 @@ func (s *TableTestSuite) TestTable_IsReferencedBy_WithReference() {
 	}
 
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-	if _, err := child.References(&s.sut, key...); err != nil {
+	if _, err := child.References(&s.sut, key); err != nil {
 		s.FailNow("unable to establish reference to table", err)
 	}
 
@@ -1902,7 +1902,7 @@ func (s *TableTestSuite) TestTable_References_InsertQuery() {
 			}
 
 			key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-			ref, err := child.References(&parent, key...)
+			ref, err := child.References(&parent, key)
 			if err != nil {
 				s.FailNow("unable to create reference between parent and child tables", err)
 			}
@@ -2009,7 +2009,7 @@ func (s *TableTestSuite) TestTable_References_InsertQueryWithArgs() {
 			}
 
 			key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-			ref, err := child.References(&parent, key...)
+			ref, err := child.References(&parent, key)
 			if err != nil {
 				s.FailNow("unable to create reference between parent and child tables", err)
 			}
@@ -2550,7 +2550,7 @@ func (s *TableTestSuite) TestTable_References_UpdateQuery() {
 			}
 
 			key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-			ref, err := child.References(&parent, key...)
+			ref, err := child.References(&parent, key)
 			if err != nil {
 				s.FailNow("unable to create reference between parent and child tables", err)
 			}
@@ -2657,7 +2657,7 @@ func (s *TableTestSuite) TestTable_References_UpdateQueryWithArgs() {
 			}
 
 			key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-			ref, err := child.References(&parent, key...)
+			ref, err := child.References(&parent, key)
 			if err != nil {
 				s.FailNow("unable to create reference between parent and child tables", err)
 			}
@@ -3127,7 +3127,7 @@ func (s *TableTestSuite) TestTable_References_DeleteQuery() {
 			}
 
 			key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-			ref, err := child.References(&parent, key...)
+			ref, err := child.References(&parent, key)
 			if err != nil {
 				s.FailNow("unable to create reference between parent and child tables", err)
 			}
@@ -3234,7 +3234,7 @@ func (s *TableTestSuite) TestTable_References_DeleteQueryWithArgs() {
 			}
 
 			key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-			ref, err := child.References(&parent, key...)
+			ref, err := child.References(&parent, key)
 			if err != nil {
 				s.FailNow("unable to create reference between parent and child tables", err)
 			}
@@ -3695,7 +3695,7 @@ func (s *TableTestSuite) TestTable_References_SelectQuery() {
 			}
 
 			key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-			ref, err := child.References(&parent, key...)
+			ref, err := child.References(&parent, key)
 			if err != nil {
 				s.FailNow("unable to create reference between parent and child tables", err)
 			}
@@ -3802,7 +3802,7 @@ func (s *TableTestSuite) TestTable_References_SelectQueryWithArgs() {
 			}
 
 			key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-			ref, err := child.References(&parent, key...)
+			ref, err := child.References(&parent, key)
 			if err != nil {
 				s.FailNow("unable to create reference between parent and child tables", err)
 			}
@@ -3886,7 +3886,7 @@ func (s *TableTestSuite) TestTable_FindReferences() {
 			preparations: func(child, parent *morph.Table) {
 				key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
 
-				_, err := child.References(parent, key...)
+				_, err := child.References(parent, key)
 				if err != nil {
 					s.FailNow("unable to create reference between parent and child tables", err)
 				}
@@ -3903,7 +3903,7 @@ func (s *TableTestSuite) TestTable_FindReferences() {
 			preparations: func(child, parent *morph.Table) {
 				key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
 
-				_, err := child.References(parent, key...)
+				_, err := child.References(parent, key)
 				if err != nil {
 					s.FailNow("unable to create reference between parent and child tables", err)
 				}
@@ -3983,7 +3983,7 @@ func (s *TableTestSuite) TestTable_FindReference() {
 			preparations: func(child, parent *morph.Table) {
 				key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
 
-				_, err := child.References(parent, key...)
+				_, err := child.References(parent, key)
 				if err != nil {
 					s.FailNow("unable to create reference between parent and child tables", err)
 				}
@@ -4001,7 +4001,7 @@ func (s *TableTestSuite) TestTable_FindReference() {
 			preparations: func(child, parent *morph.Table) {
 				key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
 
-				_, err := child.References(parent, key...)
+				_, err := child.References(parent, key)
 				if err != nil {
 					s.FailNow("unable to create reference between parent and child tables", err)
 				}

--- a/table_test.go
+++ b/table_test.go
@@ -53,7 +53,9 @@ func (s *TableTestSuite) TestTable_IsReferenced_WithReference() {
 	}
 
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-	child.References(&s.sut, key...)
+	if _, err := child.References(&s.sut, key...); err != nil {
+		s.FailNow("unable to establish reference to table", err)
+	}
 
 	// action.
 	referenced := s.sut.IsReferenced()
@@ -115,7 +117,9 @@ func (s *TableTestSuite) TestTable_ReferenceTo_WithReference() {
 	}
 
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-	child.References(&s.sut, key...)
+	if _, err := child.References(&s.sut, key...); err != nil {
+		s.FailNow("unable to establish reference to table", err)
+	}
 
 	// action.
 	ref, err := child.ReferenceTo(s.sut)
@@ -186,7 +190,9 @@ func (s *TableTestSuite) TestTable_HasReferenceTo_WithReference() {
 	}
 
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-	child.References(&s.sut, key...)
+	if _, err := child.References(&s.sut, key...); err != nil {
+		s.FailNow("unable to establish reference to table", err)
+	}
 
 	// action.
 	references := child.HasReferenceTo(s.sut)
@@ -253,7 +259,9 @@ func (s *TableTestSuite) TestTable_ReferencesTo_WithReferences() {
 	}
 
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-	child.References(&s.sut, key...)
+	if _, err := child.References(&s.sut, key...); err != nil {
+		s.FailNow("unable to establish reference to table", err)
+	}
 
 	// action.
 	tables := child.ReferencesTo()
@@ -321,7 +329,9 @@ func (s *TableTestSuite) TestTable_ReferencedBy_WithReferences() {
 	}
 
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-	child.References(&s.sut, key...)
+	if _, err := child.References(&s.sut, key...); err != nil {
+		s.FailNow("unable to establish reference to table", err)
+	}
 
 	// action.
 	tables := s.sut.ReferencedBy()
@@ -384,7 +394,9 @@ func (s *TableTestSuite) TestTable_IsReferencedBy_WithReference() {
 	}
 
 	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
-	child.References(&s.sut, key...)
+	if _, err := child.References(&s.sut, key...); err != nil {
+		s.FailNow("unable to establish reference to table", err)
+	}
 
 	// action.
 	referenced := s.sut.IsReferencedBy(child)

--- a/table_test.go
+++ b/table_test.go
@@ -27,6 +27,404 @@ func (s *TableTestSuite) SetupSubTest() {
 	s.sut = morph.Table{}
 }
 
+func (s *TableTestSuite) TestTable_IsReferenced_WithReference() {
+	// arrange.
+	name := "test"
+	model := TestModel{
+		ID:   1,
+		Name: &name,
+		Another: AnotherTestModel{
+			ModelID:     1,
+			ID:          2,
+			Title:       "another",
+			Description: nil,
+		},
+	}
+
+	var err error
+	s.sut, err = morph.Reflect(&model)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	child, err := morph.Reflect(&model.Another)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+	child.References(&s.sut, key...)
+
+	// action.
+	referenced := s.sut.IsReferenced()
+
+	// assert.
+	s.True(referenced)
+}
+
+func (s *TableTestSuite) TestTable_IsReferenced_WithoutReference() {
+	// arrange.
+	name := "test"
+	model := TestModel{
+		ID:   1,
+		Name: &name,
+		Another: AnotherTestModel{
+			ModelID:     1,
+			ID:          2,
+			Title:       "another",
+			Description: nil,
+		},
+	}
+
+	var err error
+	s.sut, err = morph.Reflect(&model)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	// action.
+	referenced := s.sut.IsReferenced()
+
+	// assert.
+	s.False(referenced)
+}
+
+func (s *TableTestSuite) TestTable_ReferenceTo_WithReference() {
+	// arrange.
+	name := "test"
+	model := TestModel{
+		ID:   1,
+		Name: &name,
+		Another: AnotherTestModel{
+			ModelID:     1,
+			ID:          2,
+			Title:       "another",
+			Description: nil,
+		},
+	}
+
+	var err error
+	s.sut, err = morph.Reflect(&model)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	child, err := morph.Reflect(&model.Another)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+	child.References(&s.sut, key...)
+
+	// action.
+	ref, err := child.ReferenceTo(s.sut)
+
+	// assert.
+	s.Require().NoError(err)
+	s.True(ref.Child().Equals(child))
+	s.True(ref.Parent().Equals(s.sut))
+	s.Equal(child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" }), ref.ForeignKey())
+}
+
+func (s *TableTestSuite) TestTable_ReferenceTo_WithoutReference() {
+	// arrange.
+	name := "test"
+	model := TestModel{
+		ID:   1,
+		Name: &name,
+		Another: AnotherTestModel{
+			ModelID:     1,
+			ID:          2,
+			Title:       "another",
+			Description: nil,
+		},
+	}
+
+	var err error
+	s.sut, err = morph.Reflect(&model)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	child, err := morph.Reflect(&model.Another)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	// action.
+	ref, err := child.ReferenceTo(s.sut)
+
+	// assert.
+	s.ErrorIs(err, morph.ErrMissingReference)
+	s.Empty(ref)
+}
+
+func (s *TableTestSuite) TestTable_HasReferenceTo_WithReference() {
+	// arrange.
+	name := "test"
+	model := TestModel{
+		ID:   1,
+		Name: &name,
+		Another: AnotherTestModel{
+			ModelID:     1,
+			ID:          2,
+			Title:       "another",
+			Description: nil,
+		},
+	}
+
+	var err error
+	s.sut, err = morph.Reflect(&model)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	child, err := morph.Reflect(&model.Another)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+	child.References(&s.sut, key...)
+
+	// action.
+	references := child.HasReferenceTo(s.sut)
+
+	// assert.
+	s.True(references)
+}
+
+func (s *TableTestSuite) TestTable_HasReferenceTo_WithoutReference() {
+	// arrange.
+	name := "test"
+	model := TestModel{
+		ID:   1,
+		Name: &name,
+		Another: AnotherTestModel{
+			ModelID:     1,
+			ID:          2,
+			Title:       "another",
+			Description: nil,
+		},
+	}
+
+	var err error
+	s.sut, err = morph.Reflect(&model)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	child, err := morph.Reflect(&model.Another)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	// action.
+	references := child.HasReferenceTo(s.sut)
+
+	// assert.
+	s.False(references)
+}
+
+func (s *TableTestSuite) TestTable_ReferencesTo_WithReferences() {
+	// arrange.
+	name := "test"
+	model := TestModel{
+		ID:   1,
+		Name: &name,
+		Another: AnotherTestModel{
+			ModelID:     1,
+			ID:          2,
+			Title:       "another",
+			Description: nil,
+		},
+	}
+
+	var err error
+	s.sut, err = morph.Reflect(&model)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	child, err := morph.Reflect(&model.Another)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+	child.References(&s.sut, key...)
+
+	// action.
+	tables := child.ReferencesTo()
+
+	// assert.
+	s.Len(tables, 1)
+	s.True(tables[0].Equals(s.sut))
+}
+
+func (s *TableTestSuite) TestTable_ReferencesTo_WithoutReferences() {
+	// arrange.
+	name := "test"
+	model := TestModel{
+		ID:   1,
+		Name: &name,
+		Another: AnotherTestModel{
+			ModelID:     1,
+			ID:          2,
+			Title:       "another",
+			Description: nil,
+		},
+	}
+
+	var err error
+	s.sut, err = morph.Reflect(&model)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	child, err := morph.Reflect(&model.Another)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	// action.
+	tables := child.ReferencesTo()
+
+	// assert.
+	s.Len(tables, 0)
+}
+
+func (s *TableTestSuite) TestTable_ReferencedBy_WithReferences() {
+	// arrange.
+	name := "test"
+	model := TestModel{
+		ID:   1,
+		Name: &name,
+		Another: AnotherTestModel{
+			ModelID:     1,
+			ID:          2,
+			Title:       "another",
+			Description: nil,
+		},
+	}
+
+	var err error
+	s.sut, err = morph.Reflect(&model)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	child, err := morph.Reflect(&model.Another)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+	child.References(&s.sut, key...)
+
+	// action.
+	tables := s.sut.ReferencedBy()
+
+	// assert.
+	s.Len(tables, 1)
+	s.True(tables[0].Equals(child))
+}
+
+func (s *TableTestSuite) TestTable_ReferencedBy_WithoutReferences() {
+	// arrange.
+	name := "test"
+	model := TestModel{
+		ID:   1,
+		Name: &name,
+		Another: AnotherTestModel{
+			ModelID:     1,
+			ID:          2,
+			Title:       "another",
+			Description: nil,
+		},
+	}
+
+	var err error
+	s.sut, err = morph.Reflect(&model)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	// action.
+	tables := s.sut.ReferencedBy()
+
+	// assert.
+	s.Len(tables, 0)
+}
+
+func (s *TableTestSuite) TestTable_IsReferencedBy_WithReference() {
+	// arrange.
+	name := "test"
+	model := TestModel{
+		ID:   1,
+		Name: &name,
+		Another: AnotherTestModel{
+			ModelID:     1,
+			ID:          2,
+			Title:       "another",
+			Description: nil,
+		},
+	}
+
+	var err error
+	s.sut, err = morph.Reflect(&model)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	child, err := morph.Reflect(&model.Another)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+	child.References(&s.sut, key...)
+
+	// action.
+	referenced := s.sut.IsReferencedBy(child)
+
+	// assert.
+	s.True(referenced)
+}
+
+func (s *TableTestSuite) TestTable_IsReferencedBy_WithoutReference() {
+	// arrange.
+	name := "test"
+	model := TestModel{
+		ID:   1,
+		Name: &name,
+		Another: AnotherTestModel{
+			ModelID:     1,
+			ID:          2,
+			Title:       "another",
+			Description: nil,
+		},
+	}
+
+	var err error
+	s.sut, err = morph.Reflect(&model)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	child, err := morph.Reflect(&model.Another)
+	if err != nil {
+		s.FailNow("unable to reflect in test", err)
+	}
+
+	// action.
+	referenced := s.sut.IsReferencedBy(child)
+
+	// assert.
+	s.False(referenced)
+}
+
 func (s *TableTestSuite) TestTable_TypeName() {
 	// arrange.
 	expectedTypeName := "example.User"
@@ -342,6 +740,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 						ID:          2,
 						Title:       "another",
 						Description: nil,
+						ModelID:     1,
 					},
 				}
 			},
@@ -369,6 +768,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 						ID:          2,
 						Title:       "another",
 						Description: nil,
+						ModelID:     1,
 					},
 				}
 			},
@@ -392,6 +792,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 					ID:   1,
 					Name: nil,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -448,6 +849,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -475,6 +877,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -501,6 +904,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 					ID:   1,
 					Name: nil,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -557,6 +961,7 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -584,6 +989,7 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -610,6 +1016,7 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 					ID:   1,
 					Name: nil,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -673,6 +1080,7 @@ func (s *TableTestSuite) TestTable_MustEvaluateValue() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -740,6 +1148,7 @@ func (s *TableTestSuite) TestTable_MustEvaluatePointer() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -921,6 +1330,7 @@ func (s *TableTestSuite) TestTable_InsertQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -941,6 +1351,7 @@ func (s *TableTestSuite) TestTable_InsertQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -961,6 +1372,7 @@ func (s *TableTestSuite) TestTable_InsertQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -981,6 +1393,7 @@ func (s *TableTestSuite) TestTable_InsertQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1035,6 +1448,7 @@ func (s *TableTestSuite) TestTable_MustInsertQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1055,6 +1469,7 @@ func (s *TableTestSuite) TestTable_MustInsertQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1075,6 +1490,7 @@ func (s *TableTestSuite) TestTable_MustInsertQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1095,6 +1511,7 @@ func (s *TableTestSuite) TestTable_MustInsertQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1144,6 +1561,7 @@ func (s *TableTestSuite) TestTable_InsertQueryWithArgs() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1165,6 +1583,7 @@ func (s *TableTestSuite) TestTable_InsertQueryWithArgs() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1186,6 +1605,7 @@ func (s *TableTestSuite) TestTable_InsertQueryWithArgs() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1255,6 +1675,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1274,6 +1695,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 					ID:   1,
 					Name: nil,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1294,6 +1716,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1314,6 +1737,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1334,6 +1758,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1388,6 +1813,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1407,6 +1833,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 					ID:   1,
 					Name: nil,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1427,6 +1854,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1447,6 +1875,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1467,6 +1896,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1516,6 +1946,7 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1536,6 +1967,7 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 					ID:   1,
 					Name: nil,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1557,6 +1989,7 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1578,6 +2011,7 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1647,6 +2081,7 @@ func (s *TableTestSuite) TestTable_DeleteQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1667,6 +2102,7 @@ func (s *TableTestSuite) TestTable_DeleteQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1687,6 +2123,7 @@ func (s *TableTestSuite) TestTable_DeleteQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1707,6 +2144,7 @@ func (s *TableTestSuite) TestTable_DeleteQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1761,6 +2199,7 @@ func (s *TableTestSuite) TestTable_MustDeleteQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1781,6 +2220,7 @@ func (s *TableTestSuite) TestTable_MustDeleteQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1801,6 +2241,7 @@ func (s *TableTestSuite) TestTable_MustDeleteQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1821,6 +2262,7 @@ func (s *TableTestSuite) TestTable_MustDeleteQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1870,6 +2312,7 @@ func (s *TableTestSuite) TestTable_DeleteQueryWithArgs() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1891,6 +2334,7 @@ func (s *TableTestSuite) TestTable_DeleteQueryWithArgs() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1912,6 +2356,7 @@ func (s *TableTestSuite) TestTable_DeleteQueryWithArgs() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1956,6 +2401,238 @@ func (s *TableTestSuite) TestTable_DeleteQueryWithArgs_InvalidTable() {
 	s.Empty(args)
 }
 
+func (s *TableTestSuite) TestTable_References_DeleteQuery() {
+	tests := []struct {
+		name         string
+		queryOptions []morph.QueryOption
+		preparations func() TestModel
+		assertions   func(query string, err error)
+	}{
+		{
+			name:         "NoOptions",
+			queryOptions: []morph.QueryOption{},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("DELETE FROM another_test_models WHERE 1=1 AND model_id = ?;", query)
+			},
+		},
+		{
+			name:         "WithPlaceholder_NoOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", false)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("DELETE FROM another_test_models WHERE 1=1 AND model_id = $;", query)
+			},
+		},
+		{
+			name:         "WithPlaceholder_WithOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", true)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("DELETE FROM another_test_models WHERE 1=1 AND model_id = $1;", query)
+			},
+		},
+		{
+			name:         "WithNamedParameters",
+			queryOptions: []morph.QueryOption{morph.WithNamedParameters()},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("DELETE FROM another_test_models WHERE 1=1 AND model_id = :model_id;", query)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// arrange.
+			model := test.preparations()
+
+			var err error
+			s.sut, err = morph.Reflect(&model)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+			parent := s.sut
+
+			child, err := morph.Reflect(&model.Another)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+
+			key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+			ref, err := child.References(&parent, key...)
+			if err != nil {
+				s.FailNow("unable to create reference between parent and child tables", err)
+			}
+
+			// action.
+			query, err := ref.DeleteQuery(test.queryOptions...)
+
+			// assert.
+			test.assertions(query, err)
+		})
+	}
+}
+
+func (s *TableTestSuite) TestTable_References_DeleteQueryWithArgs() {
+	tests := []struct {
+		name         string
+		queryOptions []morph.QueryOption
+		preparations func() TestModel
+		assertions   func(obj TestModel, query string, args []any, err error)
+	}{
+		{
+			name:         "NoOptions",
+			queryOptions: []morph.QueryOption{},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(obj TestModel, query string, args []any, err error) {
+				s.Require().NoError(err)
+				s.Equal("DELETE FROM another_test_models WHERE 1=1 AND model_id = ?;", query)
+				s.ElementsMatch([]any{obj.ID}, args)
+			},
+		},
+		{
+			name:         "WithPlaceholder_NoOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", false)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(obj TestModel, query string, args []any, err error) {
+				s.Require().NoError(err)
+				s.Equal("DELETE FROM another_test_models WHERE 1=1 AND model_id = $;", query)
+				s.ElementsMatch([]any{obj.ID}, args)
+			},
+		},
+		{
+			name:         "WithPlaceholder_WithOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", true)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(obj TestModel, query string, args []any, err error) {
+				s.Require().NoError(err)
+				s.Equal("DELETE FROM another_test_models WHERE 1=1 AND model_id = $1;", query)
+				s.ElementsMatch([]any{obj.ID}, args)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// arrange.
+			model := test.preparations()
+
+			var err error
+			s.sut, err = morph.Reflect(&model)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+			parent := s.sut
+
+			child, err := morph.Reflect(&model.Another)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+
+			key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+			ref, err := child.References(&parent, key...)
+			if err != nil {
+				s.FailNow("unable to create reference between parent and child tables", err)
+			}
+
+			// action.
+			query, args, err := ref.DeleteQueryWithArgs(model.Another, test.queryOptions...)
+
+			// assert.
+			test.assertions(model, query, args, err)
+		})
+	}
+}
+
 func (s *TableTestSuite) TestTable_SelectQuery() {
 	tests := []struct {
 		name         string
@@ -1972,6 +2649,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -1992,6 +2670,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -2012,6 +2691,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -2032,6 +2712,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -2086,6 +2767,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -2106,6 +2788,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -2126,6 +2809,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -2146,6 +2830,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -2195,6 +2880,7 @@ func (s *TableTestSuite) TestTable_SelectQueryWithArgs() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -2216,6 +2902,7 @@ func (s *TableTestSuite) TestTable_SelectQueryWithArgs() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -2237,6 +2924,7 @@ func (s *TableTestSuite) TestTable_SelectQueryWithArgs() {
 					ID:   1,
 					Name: &name,
 					Another: AnotherTestModel{
+						ModelID:     1,
 						ID:          2,
 						Title:       "another",
 						Description: nil,
@@ -2281,9 +2969,242 @@ func (s *TableTestSuite) TestTable_SelectQueryWithArgs_InvalidTable() {
 	s.Empty(args)
 }
 
+func (s *TableTestSuite) TestTable_References_SelectQuery() {
+	tests := []struct {
+		name         string
+		queryOptions []morph.QueryOption
+		preparations func() TestModel
+		assertions   func(query string, err error)
+	}{
+		{
+			name:         "NoOptions",
+			queryOptions: []morph.QueryOption{},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = ?;", query)
+			},
+		},
+		{
+			name:         "WithPlaceholder_NoOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", false)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = $;", query)
+			},
+		},
+		{
+			name:         "WithPlaceholder_WithOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", true)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = $1;", query)
+			},
+		},
+		{
+			name:         "WithNamedParameters",
+			queryOptions: []morph.QueryOption{morph.WithNamedParameters()},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(query string, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = :model_id;", query)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// arrange.
+			model := test.preparations()
+
+			var err error
+			s.sut, err = morph.Reflect(&model)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+			parent := s.sut
+
+			child, err := morph.Reflect(&model.Another)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+
+			key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+			ref, err := child.References(&parent, key...)
+			if err != nil {
+				s.FailNow("unable to create reference between parent and child tables", err)
+			}
+
+			// action.
+			query, err := ref.SelectQuery(test.queryOptions...)
+
+			// assert.
+			test.assertions(query, err)
+		})
+	}
+}
+
+func (s *TableTestSuite) TestTable_References_SelectQueryWithArgs() {
+	tests := []struct {
+		name         string
+		queryOptions []morph.QueryOption
+		preparations func() TestModel
+		assertions   func(obj TestModel, query string, args []any, err error)
+	}{
+		{
+			name:         "NoOptions",
+			queryOptions: []morph.QueryOption{},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(obj TestModel, query string, args []any, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = ?;", query)
+				s.ElementsMatch([]any{obj.ID}, args)
+			},
+		},
+		{
+			name:         "WithPlaceholder_NoOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", false)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(obj TestModel, query string, args []any, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = $;", query)
+				s.ElementsMatch([]any{obj.ID}, args)
+			},
+		},
+		{
+			name:         "WithPlaceholder_WithOrdering",
+			queryOptions: []morph.QueryOption{morph.WithPlaceholder("$", true)},
+			preparations: func() TestModel {
+				name := "test"
+				return TestModel{
+					ID:   1,
+					Name: &name,
+					Another: AnotherTestModel{
+						ModelID:     1,
+						ID:          2,
+						Title:       "another",
+						Description: nil,
+					},
+				}
+			},
+			assertions: func(obj TestModel, query string, args []any, err error) {
+				s.Require().NoError(err)
+				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = $1;", query)
+				s.ElementsMatch([]any{obj.ID}, args)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// arrange.
+			model := test.preparations()
+
+			var err error
+			s.sut, err = morph.Reflect(&model)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+			parent := s.sut
+
+			child, err := morph.Reflect(&model.Another)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+
+			key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+			ref, err := child.References(&parent, key...)
+			if err != nil {
+				s.FailNow("unable to create reference between parent and child tables", err)
+			}
+
+			// action.
+			query, args, err := ref.SelectQueryWithArgs(model.Another, test.queryOptions...)
+
+			// assert.
+			test.assertions(model, query, args, err)
+		})
+	}
+}
+
 func (s *TableTestSuite) TestTable_EvaluationResults_Empties() {
 	// arrange.
 	m := AnotherTestModel{
+		ModelID:     1,
 		ID:          2,
 		Title:       "another",
 		Description: nil,
@@ -2307,6 +3228,7 @@ func (s *TableTestSuite) TestTable_EvaluationResults_Empties() {
 func (s *TableTestSuite) TestTable_EvaluationResults_NonEmpties() {
 	// arrange.
 	m := AnotherTestModel{
+		ModelID:     1,
 		ID:          2,
 		Title:       "another",
 		Description: nil,
@@ -2323,6 +3245,197 @@ func (s *TableTestSuite) TestTable_EvaluationResults_NonEmpties() {
 
 	// assert.
 	s.NoError(err)
-	s.Len(result.NonEmpties(), 2)
-	s.ElementsMatch(result.NonEmpties(), []string{"id", "title"})
+	s.Len(result.NonEmpties(), 3)
+	s.ElementsMatch(result.NonEmpties(), []string{"id", "title", "model_id"})
+}
+
+func (s *TableTestSuite) TestTable_FindReferences() {
+	tests := []struct {
+		name         string
+		preparations func(child, parent *morph.Table)
+		predicate    func(ref morph.Reference) bool
+		assertions   func(refs []morph.Reference, child, parent *morph.Table)
+	}{
+		{
+			name:         "NoReferences",
+			preparations: func(child, parent *morph.Table) {},
+			predicate: func(ref morph.Reference) bool {
+				return ref.Child().Name() == "another_test_models"
+			},
+			assertions: func(refs []morph.Reference, child, parent *morph.Table) {
+				s.Len(refs, 0)
+			},
+		},
+		{
+			name: "NoMatchingReferences",
+			preparations: func(child, parent *morph.Table) {
+				key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+
+				_, err := child.References(parent, key...)
+				if err != nil {
+					s.FailNow("unable to create reference between parent and child tables", err)
+				}
+			},
+			predicate: func(ref morph.Reference) bool {
+				return ref.Child().Name() == "foos"
+			},
+			assertions: func(refs []morph.Reference, child, parent *morph.Table) {
+				s.Len(refs, 0)
+			},
+		},
+		{
+			name: "MatchingReferences",
+			preparations: func(child, parent *morph.Table) {
+				key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+
+				_, err := child.References(parent, key...)
+				if err != nil {
+					s.FailNow("unable to create reference between parent and child tables", err)
+				}
+			},
+			predicate: func(ref morph.Reference) bool {
+				return ref.Child().Name() == "another_test_models"
+			},
+			assertions: func(refs []morph.Reference, child, parent *morph.Table) {
+				s.Require().Len(refs, 1)
+				s.True(refs[0].Child().Equals(*child))
+				s.True(refs[0].Parent().Equals(*parent))
+				s.Equal(
+					child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" }),
+					refs[0].ForeignKey(),
+				)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// arrange.
+			name := "test"
+			model := TestModel{
+				ID:   1,
+				Name: &name,
+				Another: AnotherTestModel{
+					ModelID:     1,
+					ID:          2,
+					Title:       "another",
+					Description: nil,
+				},
+			}
+
+			var err error
+			s.sut, err = morph.Reflect(&model)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+
+			child, err := morph.Reflect(&model.Another)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+
+			test.preparations(&child, &s.sut)
+
+			// action.
+			refs := s.sut.FindReferences(test.predicate)
+
+			// assert.
+			test.assertions(refs, &child, &s.sut)
+		})
+	}
+}
+
+func (s *TableTestSuite) TestTable_FindReference() {
+	tests := []struct {
+		name         string
+		preparations func(child, parent *morph.Table)
+		predicate    func(ref morph.Reference) bool
+		assertions   func(ref morph.Reference, ok bool, child, parent *morph.Table)
+	}{
+		{
+			name:         "NoReferences",
+			preparations: func(child, parent *morph.Table) {},
+			predicate: func(ref morph.Reference) bool {
+				return ref.Child().Name() == "another_test_models"
+			},
+			assertions: func(ref morph.Reference, ok bool, child, parent *morph.Table) {
+				s.False(ok)
+				s.Empty(ref)
+			},
+		},
+		{
+			name: "NoMatchingReferences",
+			preparations: func(child, parent *morph.Table) {
+				key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+
+				_, err := child.References(parent, key...)
+				if err != nil {
+					s.FailNow("unable to create reference between parent and child tables", err)
+				}
+			},
+			predicate: func(ref morph.Reference) bool {
+				return ref.Child().Name() == "foos"
+			},
+			assertions: func(ref morph.Reference, ok bool, child, parent *morph.Table) {
+				s.False(ok)
+				s.Empty(ref)
+			},
+		},
+		{
+			name: "MatchingReferences",
+			preparations: func(child, parent *morph.Table) {
+				key := child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" })
+
+				_, err := child.References(parent, key...)
+				if err != nil {
+					s.FailNow("unable to create reference between parent and child tables", err)
+				}
+			},
+			predicate: func(ref morph.Reference) bool {
+				return ref.Child().Name() == "another_test_models"
+			},
+			assertions: func(ref morph.Reference, ok bool, child, parent *morph.Table) {
+				s.True(ok)
+				s.True(ref.Child().Equals(*child))
+				s.True(ref.Parent().Equals(*parent))
+				s.Equal(child.FindColumns(func(c morph.Column) bool { return c.Name() == "model_id" }), ref.ForeignKey())
+			},
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// arrange.
+			name := "test"
+			model := TestModel{
+				ID:   1,
+				Name: &name,
+				Another: AnotherTestModel{
+					ModelID:     1,
+					ID:          2,
+					Title:       "another",
+					Description: nil,
+				},
+			}
+
+			var err error
+			s.sut, err = morph.Reflect(&model)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+
+			child, err := morph.Reflect(&model.Another)
+			if err != nil {
+				s.FailNow("unable to reflect in test", err)
+			}
+
+			test.preparations(&child, &s.sut)
+
+			// action.
+			ref, ok := s.sut.FindReference(test.predicate)
+
+			// assert.
+			test.assertions(ref, ok, &child, &s.sut)
+		})
+	}
 }

--- a/table_test.go
+++ b/table_test.go
@@ -662,6 +662,11 @@ func (s *TableTestSuite) TestTable_SetAlias() {
 	s.Equal(expectedAlias, s.sut.Alias())
 }
 
+func (s *TableTestSuite) TestTable_HasColumn_NoColumns() {
+	// action + assert.
+	s.False(s.sut.HasColumn("username"))
+}
+
 func (s *TableTestSuite) TestTable_HasColumn_WithExistingColumn() {
 	// arrange.
 	usernameField := "Username"

--- a/table_test.go
+++ b/table_test.go
@@ -662,6 +662,39 @@ func (s *TableTestSuite) TestTable_SetAlias() {
 	s.Equal(expectedAlias, s.sut.Alias())
 }
 
+func (s *TableTestSuite) TestTable_HasColumn_WithExistingColumn() {
+	// arrange.
+	usernameField := "Username"
+	usernameColumnName := "username"
+	passwordField := "Password"
+	passwordColumnName := "password"
+	usernameColumn := morph.Column{}
+	usernameColumn.SetField(usernameField)
+	usernameColumn.SetName(usernameColumnName)
+	passwordColumn := morph.Column{}
+	passwordColumn.SetField(passwordField)
+	passwordColumn.SetName(passwordColumnName)
+	columns := []morph.Column{usernameColumn, passwordColumn}
+	s.Require().NoError(s.sut.AddColumns(columns...))
+
+	// action + assert.
+	s.True(s.sut.HasColumn(usernameColumnName))
+}
+
+func (s *TableTestSuite) TestTable_HasColumn_WithNonExistentColumn() {
+	// arrange.
+	usernameField := "Username"
+	usernameColumnName := "username"
+	usernameColumn := morph.Column{}
+	usernameColumn.SetField(usernameField)
+	usernameColumn.SetName(usernameColumnName)
+	columns := []morph.Column{usernameColumn}
+	s.Require().NoError(s.sut.AddColumns(columns...))
+
+	// action + assert.
+	s.False(s.sut.HasColumn("password"))
+}
+
 func (s *TableTestSuite) TestTable_ColumnNames() {
 	// arrange.
 	usernameField := "Username"

--- a/table_test.go
+++ b/table_test.go
@@ -3660,7 +3660,7 @@ func (s *TableTestSuite) TestTable_References_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = ?;", query)
+				s.Equal("SELECT A.description, A.id, A.model_id, A.title FROM another_test_models AS A WHERE 1=1 AND A.model_id = ?;", query)
 			},
 		},
 		{
@@ -3681,7 +3681,7 @@ func (s *TableTestSuite) TestTable_References_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = $;", query)
+				s.Equal("SELECT A.description, A.id, A.model_id, A.title FROM another_test_models AS A WHERE 1=1 AND A.model_id = $;", query)
 			},
 		},
 		{
@@ -3702,7 +3702,7 @@ func (s *TableTestSuite) TestTable_References_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = $1;", query)
+				s.Equal("SELECT A.description, A.id, A.model_id, A.title FROM another_test_models AS A WHERE 1=1 AND A.model_id = $1;", query)
 			},
 		},
 		{
@@ -3723,7 +3723,7 @@ func (s *TableTestSuite) TestTable_References_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = :model_id;", query)
+				s.Equal("SELECT A.description, A.id, A.model_id, A.title FROM another_test_models AS A WHERE 1=1 AND A.model_id = :model_id;", query)
 			},
 		},
 	}
@@ -3785,7 +3785,7 @@ func (s *TableTestSuite) TestTable_References_SelectQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = ?;", query)
+				s.Equal("SELECT A.description, A.id, A.model_id, A.title FROM another_test_models AS A WHERE 1=1 AND A.model_id = ?;", query)
 				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},
@@ -3807,7 +3807,7 @@ func (s *TableTestSuite) TestTable_References_SelectQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = $;", query)
+				s.Equal("SELECT A.description, A.id, A.model_id, A.title FROM another_test_models AS A WHERE 1=1 AND A.model_id = $;", query)
 				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},
@@ -3829,7 +3829,7 @@ func (s *TableTestSuite) TestTable_References_SelectQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT description, id, model_id, title FROM another_test_models AS A WHERE 1=1 AND A.model_id = $1;", query)
+				s.Equal("SELECT A.description, A.id, A.model_id, A.title FROM another_test_models AS A WHERE 1=1 AND A.model_id = $1;", query)
 				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},

--- a/test_config.json
+++ b/test_config.json
@@ -39,6 +39,51 @@
           "fieldType": "string",
           "fieldStrategy": "method",
           "primaryKey": false
+        },
+        {
+          "name": "business_uuid",
+          "field": "BusinessUUID",
+          "fieldType": "string",
+          "fieldStrategy": "method",
+          "primaryKey": false
+        }
+      ],
+      "references": [
+        {
+          "tableName": "business",
+          "foreignKey": [
+            {
+              "columnName": "business_uuid"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "typeName": "example.Business",
+      "name": "business",
+      "alias": "B",
+      "columns": [
+        {
+          "name": "uuid",
+          "field": "UUID",
+          "fieldType": "string",
+          "fieldStrategy": "method",
+          "primaryKey": true
+        },
+        {
+          "name": "name",
+          "field": "Name",
+          "fieldType": "string",
+          "fieldStrategy": "method",
+          "primaryKey": false
+        },
+        {
+          "name": "establishedAt",
+          "field": "EstablishedAt",
+          "fieldType": "time.Time",
+          "fieldStrategy": "method",
+          "primaryKey": false
         }
       ]
     }


### PR DESCRIPTION
**Description**

These changes introduce the ability to capture table references, meaning one table having a foreign key relationship to another.

**Rationale**

The primary motivations for this feature is to support the ability for consumers of `morph` to "traverse" the relationships of the tables rather than having to hardcode them, and additionally to unlock query generation for references.

**Suggested Version**

`v1.6.0`

**Example Usage**

```go
package main

import (
	"fmt"
	"time"

	"github.com/freerware/morph"
)

type Starship struct {
	ID               string
	Name             string
	ManufacturedAt   time.Time
	DecommissionedAt *time.Time
	AccessCode       string `db:"-"`
}

type Pilot struct {
	ID             string
	Name           string
	StarshipID     string     `db:"starship_id"`
	LastOperatedAt *time.Time `db:"last_operated_at"`
}

func main() {
	decommissionedAt := time.Now()
	lastOperatedAt := time.Now()

	s := Starship{
		ID:               "123",
		Name:             "Millennium Falcon",
		ManufacturedAt:   time.Now(),
		DecommissionedAt: &decommissionedAt,
		AccessCode:       "secret",
	}

	hans := Pilot{
		ID:             "456",
		Name:           "Han Solo",
		StarshipID:     s.ID,
		LastOperatedAt: &lastOperatedAt,
	}

	shipTable := morph.Must(morph.Reflect(s, morph.WithTag("db"), morph.WithTableAlias("SHIP")))
	pilotTable := morph.Must(morph.Reflect(hans, morph.WithTag("db"), morph.WithTableAlias("PILOT")))
	fk := pilotTable.FindColumns(func(c morph.Column) bool {
		return c.Name() == "starship_id"
	})
	ref, err := pilotTable.References(&shipTable, fk)
	if err != nil {
		panic(err)
	}

	fmt.Println(ref.InsertQuery()) // INSERT INTO pilots (id, last_operated_at, name, starship_id) VALUES (?, ?, ?, ?); <nil>
	fmt.Println(ref.UpdateQuery()) // UPDATE pilots AS PILOT SET PILOT.last_operated_at = ?, PILOT.name = ?, PILOT.starship_id = ? WHERE 1=1 AND PILOT.id = ?; 
	fmt.Println(ref.DeleteQuery()) // DELETE FROM pilots WHERE 1=1 AND starship_id = ?;
	fmt.Println(ref.SelectQuery()) // SELECT PILOT.id, PILOT.last_operated_at, PILOT.name, PILOT.starship_id FROM pilots AS PILOT WHERE 1=1 AND PILOT.starship_id = ?;
}

```
