### PR TITLE
Support omitting struct fields using '-' tag values.

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -120,7 +120,10 @@ func fields(t reflect.Type, v reflect.Value, c ReflectConfiguration) []Column {
 
 		var tagValue string
 		if c.HasTag() {
-			tagValue = field.Tag.Get(*c.Tag)
+			tagValue = strings.TrimSpace(field.Tag.Get(*c.Tag))
+			if tagValue == "-" {
+				continue
+			}
 		}
 
 		if c.HasFieldExclusionPattern() {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -9,9 +9,10 @@ import (
 )
 
 type TestModel struct {
-	ID      int `db:"identifier"`
-	Name    *string
-	Another AnotherTestModel
+	ID          int `db:"identifier"`
+	Name        *string
+	Another     AnotherTestModel
+	MaybeIgnore bool `db:"-"`
 }
 
 func (t *TestModel) CreatedAt() time.Time {
@@ -108,7 +109,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -145,7 +152,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -182,7 +195,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -219,7 +238,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -256,7 +281,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -293,7 +324,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -330,7 +367,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -367,7 +410,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -407,7 +456,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("MAYBE_IGNORE")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -447,7 +502,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("MAYBEIGNORE")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -484,7 +545,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybeignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -521,7 +588,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("MaybeIgnore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -558,7 +631,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -595,7 +674,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -662,7 +747,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				nameColumn.SetStrategy(morph.FieldStrategyStructField)
 				nameColumn.SetFieldType("*string")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -693,7 +784,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				nameColumn.SetStrategy(morph.FieldStrategyStructField)
 				nameColumn.SetFieldType("*string")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -724,7 +821,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -755,7 +858,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -794,7 +903,13 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -870,7 +985,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -907,7 +1028,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -944,7 +1071,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -981,7 +1114,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1018,7 +1157,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1055,7 +1200,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1092,7 +1243,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1129,7 +1286,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1169,7 +1332,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("MAYBE_IGNORE")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1209,7 +1378,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("MAYBEIGNORE")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1246,7 +1421,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybeignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1283,7 +1464,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("MaybeIgnore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1320,7 +1507,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1357,7 +1550,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1425,7 +1624,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				nameColumn.SetStrategy(morph.FieldStrategyStructField)
 				nameColumn.SetFieldType("*string")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1456,7 +1661,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				nameColumn.SetStrategy(morph.FieldStrategyStructField)
 				nameColumn.SetFieldType("*string")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1487,7 +1698,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1518,7 +1735,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1557,7 +1780,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1596,7 +1825,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1635,7 +1870,13 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var maybeIgnoreColumn morph.Column
+				maybeIgnoreColumn.SetName("maybe_ignore")
+				maybeIgnoreColumn.SetField("MaybeIgnore")
+				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
+				maybeIgnoreColumn.SetFieldType("bool")
+
+				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t

--- a/table_test.go
+++ b/table_test.go
@@ -349,9 +349,10 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 				s.NoError(err)
 				s.Equal(
 					morph.EvaluationResult{
-						"id":         1,
-						"name":       "test",
-						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
+						"id":           1,
+						"name":         "test",
+						"maybe_ignore": false,
+						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
 				)
@@ -402,9 +403,10 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 				s.NoError(err)
 				s.Equal(
 					morph.EvaluationResult{
-						"id":         1,
-						"name":       nil,
-						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
+						"id":           1,
+						"name":         nil,
+						"maybe_ignore": false,
+						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
 				)
@@ -458,9 +460,10 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 				s.NoError(err)
 				s.Equal(
 					morph.EvaluationResult{
-						"id":         1,
-						"name":       "test",
-						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
+						"id":           1,
+						"name":         "test",
+						"maybe_ignore": false,
+						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
 				)
@@ -511,9 +514,10 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 				s.NoError(err)
 				s.Equal(
 					morph.EvaluationResult{
-						"id":         1,
-						"name":       nil,
-						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
+						"id":           1,
+						"name":         nil,
+						"maybe_ignore": false,
+						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
 				)
@@ -567,9 +571,10 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 				s.NoError(err)
 				s.Equal(
 					morph.EvaluationResult{
-						"id":         1,
-						"name":       "test",
-						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
+						"id":           1,
+						"name":         "test",
+						"maybe_ignore": false,
+						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
 				)
@@ -620,9 +625,10 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 				s.NoError(err)
 				s.Equal(
 					morph.EvaluationResult{
-						"id":         1,
-						"name":       nil,
-						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
+						"id":           1,
+						"name":         nil,
+						"maybe_ignore": false,
+						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
 				)
@@ -682,9 +688,10 @@ func (s *TableTestSuite) TestTable_MustEvaluateValue() {
 			assertions: func(result morph.EvaluationResult) {
 				s.Equal(
 					morph.EvaluationResult{
-						"id":         1,
-						"name":       "test",
-						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
+						"id":           1,
+						"name":         "test",
+						"maybe_ignore": false,
+						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
 				)
@@ -749,9 +756,10 @@ func (s *TableTestSuite) TestTable_MustEvaluatePointer() {
 			assertions: func(result morph.EvaluationResult) {
 				s.Equal(
 					morph.EvaluationResult{
-						"id":         1,
-						"name":       "test",
-						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
+						"id":           1,
+						"name":         "test",
+						"maybe_ignore": false,
+						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
 				)
@@ -929,7 +937,7 @@ func (s *TableTestSuite) TestTable_InsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES (?, ?, ?);", query)
+				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES (?, ?, ?, ?);", query)
 			},
 		},
 		{
@@ -949,7 +957,7 @@ func (s *TableTestSuite) TestTable_InsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES (:created_at, :id, :name);", query)
+				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES (:created_at, :id, :maybe_ignore, :name);", query)
 			},
 		},
 		{
@@ -969,7 +977,7 @@ func (s *TableTestSuite) TestTable_InsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES ($, $, $);", query)
+				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES ($, $, $, $);", query)
 			},
 		},
 		{
@@ -989,7 +997,7 @@ func (s *TableTestSuite) TestTable_InsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES ($1, $2, $3);", query)
+				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES ($1, $2, $3, $4);", query)
 			},
 		},
 	}
@@ -1043,7 +1051,7 @@ func (s *TableTestSuite) TestTable_MustInsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES (?, ?, ?);", query)
+				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES (?, ?, ?, ?);", query)
 			},
 		},
 		{
@@ -1063,7 +1071,7 @@ func (s *TableTestSuite) TestTable_MustInsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES (:created_at, :id, :name);", query)
+				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES (:created_at, :id, :maybe_ignore, :name);", query)
 			},
 		},
 		{
@@ -1083,7 +1091,7 @@ func (s *TableTestSuite) TestTable_MustInsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES ($, $, $);", query)
+				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES ($, $, $, $);", query)
 			},
 		},
 		{
@@ -1103,7 +1111,7 @@ func (s *TableTestSuite) TestTable_MustInsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES ($1, $2, $3);", query)
+				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES ($1, $2, $3, $4);", query)
 			},
 		},
 	}
@@ -1152,8 +1160,8 @@ func (s *TableTestSuite) TestTable_InsertQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES (?, ?, ?);", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID, *obj.Name}, args)
+				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES (?, ?, ?, ?);", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID, *obj.Name, obj.MaybeIgnore}, args)
 			},
 		},
 		{
@@ -1173,8 +1181,8 @@ func (s *TableTestSuite) TestTable_InsertQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES ($, $, $);", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID, *obj.Name}, args)
+				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES ($, $, $, $);", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID, *obj.Name, obj.MaybeIgnore}, args)
 			},
 		},
 		{
@@ -1194,8 +1202,8 @@ func (s *TableTestSuite) TestTable_InsertQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, name) VALUES ($1, $2, $3);", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID, *obj.Name}, args)
+				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES ($1, $2, $3, $4);", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID, *obj.Name, obj.MaybeIgnore}, args)
 			},
 		},
 	}
@@ -1263,7 +1271,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.name = ? WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ?, T.name = ? WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -1282,7 +1290,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = ? WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ? WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -1302,7 +1310,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = $, T.name = $ WHERE 1=1 AND T.id = $;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = $, T.maybe_ignore = $, T.name = $ WHERE 1=1 AND T.id = $;", query)
 			},
 		},
 		{
@@ -1322,7 +1330,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = $1, T.name = $2 WHERE 1=1 AND T.id = $3;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = $1, T.maybe_ignore = $2, T.name = $3 WHERE 1=1 AND T.id = $4;", query)
 			},
 		},
 		{
@@ -1342,7 +1350,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = :created_at, T.name = :name WHERE 1=1 AND T.id = :id;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = :created_at, T.maybe_ignore = :maybe_ignore, T.name = :name WHERE 1=1 AND T.id = :id;", query)
 			},
 		},
 	}
@@ -1396,7 +1404,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.name = ? WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ?, T.name = ? WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -1415,7 +1423,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = ? WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ? WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -1435,7 +1443,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = $, T.name = $ WHERE 1=1 AND T.id = $;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = $, T.maybe_ignore = $, T.name = $ WHERE 1=1 AND T.id = $;", query)
 			},
 		},
 		{
@@ -1455,7 +1463,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = $1, T.name = $2 WHERE 1=1 AND T.id = $3;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = $1, T.maybe_ignore = $2, T.name = $3 WHERE 1=1 AND T.id = $4;", query)
 			},
 		},
 		{
@@ -1475,7 +1483,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = :created_at, T.name = :name WHERE 1=1 AND T.id = :id;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = :created_at, T.maybe_ignore = :maybe_ignore, T.name = :name WHERE 1=1 AND T.id = :id;", query)
 			},
 		},
 	}
@@ -1524,8 +1532,8 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.name = ? WHERE 1=1 AND T.id = ?;", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), *obj.Name, obj.ID}, args)
+				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ?, T.name = ? WHERE 1=1 AND T.id = ?;", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), obj.MaybeIgnore, *obj.Name, obj.ID}, args)
 			},
 		},
 		{
@@ -1544,8 +1552,8 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = ? WHERE 1=1 AND T.id = ?;", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID}, args)
+				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ? WHERE 1=1 AND T.id = ?;", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), obj.MaybeIgnore, obj.ID}, args)
 			},
 		},
 		{
@@ -1565,8 +1573,8 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = $, T.name = $ WHERE 1=1 AND T.id = $;", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), *obj.Name, obj.ID}, args)
+				s.Equal("UPDATE test_models AS T SET T.created_at = $, T.maybe_ignore = $, T.name = $ WHERE 1=1 AND T.id = $;", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), obj.MaybeIgnore, *obj.Name, obj.ID}, args)
 			},
 		},
 		{
@@ -1586,8 +1594,8 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = $1, T.name = $2 WHERE 1=1 AND T.id = $3;", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), *obj.Name, obj.ID}, args)
+				s.Equal("UPDATE test_models AS T SET T.created_at = $1, T.maybe_ignore = $2, T.name = $3 WHERE 1=1 AND T.id = $4;", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), obj.MaybeIgnore, *obj.Name, obj.ID}, args)
 			},
 		},
 	}
@@ -1980,7 +1988,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -2000,7 +2008,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
+				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
 			},
 		},
 		{
@@ -2020,7 +2028,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
+				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
 			},
 		},
 		{
@@ -2040,7 +2048,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
+				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
 			},
 		},
 	}
@@ -2094,7 +2102,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -2114,7 +2122,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
+				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
 			},
 		},
 		{
@@ -2134,7 +2142,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
+				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
 			},
 		},
 		{
@@ -2154,7 +2162,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
+				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
 			},
 		},
 	}
@@ -2203,7 +2211,7 @@ func (s *TableTestSuite) TestTable_SelectQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
 				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},
@@ -2224,7 +2232,7 @@ func (s *TableTestSuite) TestTable_SelectQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
+				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
 				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},
@@ -2245,7 +2253,7 @@ func (s *TableTestSuite) TestTable_SelectQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
+				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
 				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},


### PR DESCRIPTION
**Description**

These changes add support for ignoring struct fields that have a struct tag with a value of `"-"`, such as `morph:"-"` or `db:"-"`. This provides an idiomatic way of choosing specific fields that are not desired to be included in the query generation or evaluation process.

**Rationale**

It is idiomatic in the Golang community to use a struct tag value of `"-"` to indicate the field should be ignored. This is used for serialization / deserialization in the standard library (such as [here](https://pkg.go.dev/encoding/json#Marshal) in the `json` package), as well as popular community supported projects such as `sqlx`.

**Suggested Version**

`v1.5.0`

**Example Usage**

```go
package main

import (
	"fmt"
	"time"

	"github.com/freerware/morph"
)

type Starship struct {
	ID               string
	Name             string
	ManufacturedAt   time.Time
	DecommissionedAt *time.Time
	AccessCode       string `db:"-"`
}

func main() {
	s := Starship{
		ID:               "123",
		Name:             "Millennium Falcon",
		ManufacturedAt:   time.Now(),
		DecommissionedAt: nil,
		AccessCode:       "secret",
	}

	table := morph.Must(morph.Reflect(s, morph.WithTag("db")))
	fmt.Println(table.InsertQuery()) // INSERT INTO starships (decommissioned_at, id, name) VALUES (?, ?, ?);
	fmt.Println(table.UpdateQuery()) // UPDATE starships AS S SET S.decommissioned_at = ?, S.name = ? WHERE 1=1 AND S.id = ?;
	fmt.Println(table.DeleteQuery()) // DELETE FROM starships WHERE 1=1 AND id = ?;
	fmt.Println(table.SelectQuery()) // SELECT decommissioned_at, id, name FROM starships WHERE 1=1 AND id = ?;
	fmt.Println(table.Evaluate(s)) // map[decommissioned_at:<nil> id:123 name:Millennium Falcon]
}
```

> [!NOTE]
>
> There is a bug above that we are going to address next - do you see it?