### PR TITLE
Add aliases for SELECT queries.

### DIFF
--- a/query.go
+++ b/query.go
@@ -104,7 +104,7 @@ const selectSQL = `
   {{- $seq := 0 -}}
   SELECT {{- if true}} {{end}}
   {{- range $idx, $col := $table.Columns -}}
-    {{$col.Name}}{{if ne $idx (sub (len $table.Columns) 1)}}, {{end}}
+    {{$table.Alias}}.{{$col.Name}}{{if ne $idx (sub (len $table.Columns) 1)}}, {{end}}
   {{- end -}}
   {{- if true}} {{end -}} FROM {{$table.Name}} AS {{$table.Alias}} WHERE 1=1
   {{- range $idx, $col := .PrimaryKeys -}}

--- a/table_test.go
+++ b/table_test.go
@@ -1988,7 +1988,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -2008,7 +2008,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
+				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
 			},
 		},
 		{
@@ -2028,7 +2028,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
+				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
 			},
 		},
 		{
@@ -2048,7 +2048,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
+				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
 			},
 		},
 	}
@@ -2102,7 +2102,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -2122,7 +2122,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
+				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
 			},
 		},
 		{
@@ -2142,7 +2142,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
+				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
 			},
 		},
 		{
@@ -2162,7 +2162,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
+				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
 			},
 		},
 	}
@@ -2211,7 +2211,7 @@ func (s *TableTestSuite) TestTable_SelectQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
 				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},
@@ -2232,7 +2232,7 @@ func (s *TableTestSuite) TestTable_SelectQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
+				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
 				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},
@@ -2253,7 +2253,7 @@ func (s *TableTestSuite) TestTable_SelectQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT created_at, id, maybe_ignore, name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
+				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
 				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},


### PR DESCRIPTION
**Description**

These changes adapt the `SELECT` query generation to include the table alias in the column list, as intended.

**Rationale**

This essentially was a bug - the alias was being included in the columns listed within the `WHERE` clause, but not for the columns in the `SELECT` portion.

**Suggested Version**

`v1.5.0`

**Example Usage**

```golang
package main

import (
	"fmt"
	"time"

	"github.com/freerware/morph"
)

type Starship struct {
	ID               string
	Name             string
	ManufacturedAt   time.Time
	DecommissionedAt *time.Time
	AccessCode       string `db:"-"`
}

func main() {
	s := Starship{
		ID:               "123",
		Name:             "Millennium Falcon",
		ManufacturedAt:   time.Now(),
		DecommissionedAt: nil,
		AccessCode:       "secret",
	}

	table := morph.Must(morph.Reflect(s, morph.WithTag("db"), morph.WithTableAlias("SHIP")))
	fmt.Println(table.SelectQuery()) // SELECT SHIP.decommissioned_at, SHIP.id, SHIP.name FROM starships AS SHIP WHERE 1=1 AND SHIP.id = ?;
}
```
