### PR TITLE
Introduce support for 'time.Time' & '*time.Time' on structs.

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -109,12 +109,8 @@ func fields(t reflect.Type, v reflect.Value, c ReflectConfiguration) []Column {
 			fieldVal = fieldVal.Elem()
 		}
 
-		// ignore fields to other structs. if we want to retrieve
-		// metadata for these fields, we should call Reflect on them directly.
-		// NOTE: it would be nice to be able to recursively reflect struct
-		// fields, but where things fall down is how we'd propogate the options
-		// to each call in a way that makes sense.
-		if fieldVal.Kind() == reflect.Struct {
+		// only struct support if for time.Time.
+		if fieldVal.Kind() == reflect.Struct && fieldVal.Type() != reflect.TypeOf(time.Time{}) {
 			continue
 		}
 
@@ -195,6 +191,7 @@ func methods(t reflect.Type, c ReflectConfiguration) []Column {
 			returnType = returnType.Elem()
 		}
 
+		// only struct support if for time.Time.
 		if returnType.Kind() == reflect.Struct && returnType != reflect.TypeOf(time.Time{}) {
 			continue
 		}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -13,6 +13,8 @@ type TestModel struct {
 	Name        *string
 	Another     AnotherTestModel
 	MaybeIgnore bool `db:"-"`
+	UpdatedAt   time.Time
+	DeletedAt   *time.Time
 }
 
 func (t *TestModel) CreatedAt() time.Time {
@@ -50,8 +52,9 @@ func TestReflectTestSuite(t *testing.T) {
 func (s *ReflectTestSuite) SetupTest() {
 	name := "test"
 	m := TestModel{
-		ID:   1,
-		Name: &name,
+		ID:        1,
+		Name:      &name,
+		UpdatedAt: time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 		Another: AnotherTestModel{
 			ID:          2,
 			Title:       "another",
@@ -115,7 +118,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -158,7 +174,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -201,7 +230,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -244,7 +286,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -287,7 +342,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -330,7 +398,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -373,7 +454,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -416,7 +510,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -462,7 +569,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("UPDATED_AT")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("DELETED_AT")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -508,7 +628,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("UPDATEDAT")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("DELETEDAT")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -551,7 +684,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updatedat")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deletedat")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -594,7 +740,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("UpdatedAt")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("DeletedAt")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -637,7 +796,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -680,7 +852,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -716,7 +901,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -753,7 +951,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -790,7 +1001,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -827,7 +1051,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -864,7 +1101,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -909,7 +1159,20 @@ func (s *ReflectTestSuite) TestReflect_WithValue() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -991,7 +1254,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1034,7 +1310,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1077,7 +1366,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1120,7 +1422,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1163,7 +1478,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1206,7 +1534,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1249,7 +1590,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1292,7 +1646,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1338,7 +1705,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("UPDATED_AT")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("DELETED_AT")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1384,7 +1764,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("UPDATEDAT")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("DELETEDAT")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1427,7 +1820,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updatedat")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deletedat")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1470,7 +1876,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("UpdatedAt")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("DeletedAt")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1513,7 +1932,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1556,7 +1988,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1593,7 +2038,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				createdAtColumn.SetStrategy(morph.FieldStrategyMethod)
 				createdAtColumn.SetFieldType("time.Time")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, createdAtColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1630,7 +2088,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1667,7 +2138,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, nameColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1704,7 +2188,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1741,7 +2238,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, createdAtColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1786,7 +2296,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, createdAtColumn, nameColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1831,7 +2354,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, createdAtColumn, nameColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t
@@ -1876,7 +2412,20 @@ func (s *ReflectTestSuite) TestReflect_WithPointer() {
 				maybeIgnoreColumn.SetStrategy(morph.FieldStrategyStructField)
 				maybeIgnoreColumn.SetFieldType("bool")
 
-				if err := t.AddColumns(append(columns, idColumn, nameColumn, createdAtColumn, maybeIgnoreColumn)...); err != nil {
+				var updatedAtColumn morph.Column
+				updatedAtColumn.SetName("updated_at")
+				updatedAtColumn.SetField("UpdatedAt")
+				updatedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				updatedAtColumn.SetFieldType("time.Time")
+
+				var deletedAtColumn morph.Column
+				deletedAtColumn.SetName("deleted_at")
+				deletedAtColumn.SetField("DeletedAt")
+				deletedAtColumn.SetStrategy(morph.FieldStrategyStructField)
+				deletedAtColumn.SetFieldType("*time.Time")
+
+				columns = append(columns, idColumn, createdAtColumn, nameColumn, maybeIgnoreColumn, updatedAtColumn, deletedAtColumn)
+				if err := t.AddColumns(columns...); err != nil {
 					s.FailNow("failed to setup expectations for test: %v", err.Error())
 				}
 				return t

--- a/table_test.go
+++ b/table_test.go
@@ -352,6 +352,8 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 						"id":           1,
 						"name":         "test",
 						"maybe_ignore": false,
+						"deleted_at":   nil,
+						"updated_at":   time.Time{},
 						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
@@ -379,6 +381,8 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 					morph.EvaluationResult{
 						"identifier": 1,
 						"name":       "test",
+						"deleted_at": nil,
+						"updated_at": time.Time{},
 						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
@@ -406,6 +410,8 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 						"id":           1,
 						"name":         nil,
 						"maybe_ignore": false,
+						"deleted_at":   nil,
+						"updated_at":   time.Time{},
 						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
@@ -463,6 +469,8 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 						"id":           1,
 						"name":         "test",
 						"maybe_ignore": false,
+						"deleted_at":   nil,
+						"updated_at":   time.Time{},
 						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
@@ -490,6 +498,8 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 					morph.EvaluationResult{
 						"identifier": 1,
 						"name":       "test",
+						"deleted_at": nil,
+						"updated_at": time.Time{},
 						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
@@ -517,6 +527,8 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 						"id":           1,
 						"name":         nil,
 						"maybe_ignore": false,
+						"deleted_at":   nil,
+						"updated_at":   time.Time{},
 						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
@@ -574,6 +586,8 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 						"id":           1,
 						"name":         "test",
 						"maybe_ignore": false,
+						"deleted_at":   nil,
+						"updated_at":   time.Time{},
 						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
@@ -601,6 +615,8 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 					morph.EvaluationResult{
 						"identifier": 1,
 						"name":       "test",
+						"deleted_at": nil,
+						"updated_at": time.Time{},
 						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
@@ -628,6 +644,8 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 						"id":           1,
 						"name":         nil,
 						"maybe_ignore": false,
+						"deleted_at":   nil,
+						"updated_at":   time.Time{},
 						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
@@ -691,6 +709,8 @@ func (s *TableTestSuite) TestTable_MustEvaluateValue() {
 						"id":           1,
 						"name":         "test",
 						"maybe_ignore": false,
+						"deleted_at":   nil,
+						"updated_at":   time.Time{},
 						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
@@ -759,6 +779,8 @@ func (s *TableTestSuite) TestTable_MustEvaluatePointer() {
 						"id":           1,
 						"name":         "test",
 						"maybe_ignore": false,
+						"deleted_at":   nil,
+						"updated_at":   time.Time{},
 						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
 					result,
@@ -937,7 +959,7 @@ func (s *TableTestSuite) TestTable_InsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES (?, ?, ?, ?);", query)
+				s.Equal("INSERT INTO test_models (created_at, deleted_at, id, maybe_ignore, name, updated_at) VALUES (?, ?, ?, ?, ?, ?);", query)
 			},
 		},
 		{
@@ -957,7 +979,7 @@ func (s *TableTestSuite) TestTable_InsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES (:created_at, :id, :maybe_ignore, :name);", query)
+				s.Equal("INSERT INTO test_models (created_at, deleted_at, id, maybe_ignore, name, updated_at) VALUES (:created_at, :deleted_at, :id, :maybe_ignore, :name, :updated_at);", query)
 			},
 		},
 		{
@@ -977,7 +999,7 @@ func (s *TableTestSuite) TestTable_InsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES ($, $, $, $);", query)
+				s.Equal("INSERT INTO test_models (created_at, deleted_at, id, maybe_ignore, name, updated_at) VALUES ($, $, $, $, $, $);", query)
 			},
 		},
 		{
@@ -997,7 +1019,7 @@ func (s *TableTestSuite) TestTable_InsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES ($1, $2, $3, $4);", query)
+				s.Equal("INSERT INTO test_models (created_at, deleted_at, id, maybe_ignore, name, updated_at) VALUES ($1, $2, $3, $4, $5, $6);", query)
 			},
 		},
 	}
@@ -1051,7 +1073,7 @@ func (s *TableTestSuite) TestTable_MustInsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES (?, ?, ?, ?);", query)
+				s.Equal("INSERT INTO test_models (created_at, deleted_at, id, maybe_ignore, name, updated_at) VALUES (?, ?, ?, ?, ?, ?);", query)
 			},
 		},
 		{
@@ -1071,7 +1093,7 @@ func (s *TableTestSuite) TestTable_MustInsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES (:created_at, :id, :maybe_ignore, :name);", query)
+				s.Equal("INSERT INTO test_models (created_at, deleted_at, id, maybe_ignore, name, updated_at) VALUES (:created_at, :deleted_at, :id, :maybe_ignore, :name, :updated_at);", query)
 			},
 		},
 		{
@@ -1091,7 +1113,7 @@ func (s *TableTestSuite) TestTable_MustInsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES ($, $, $, $);", query)
+				s.Equal("INSERT INTO test_models (created_at, deleted_at, id, maybe_ignore, name, updated_at) VALUES ($, $, $, $, $, $);", query)
 			},
 		},
 		{
@@ -1111,7 +1133,7 @@ func (s *TableTestSuite) TestTable_MustInsertQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES ($1, $2, $3, $4);", query)
+				s.Equal("INSERT INTO test_models (created_at, deleted_at, id, maybe_ignore, name, updated_at) VALUES ($1, $2, $3, $4, $5, $6);", query)
 			},
 		},
 	}
@@ -1160,8 +1182,8 @@ func (s *TableTestSuite) TestTable_InsertQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES (?, ?, ?, ?);", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID, *obj.Name, obj.MaybeIgnore}, args)
+				s.Equal("INSERT INTO test_models (created_at, deleted_at, id, maybe_ignore, name, updated_at) VALUES (?, ?, ?, ?, ?, ?);", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), any(nil), obj.ID, *obj.Name, obj.MaybeIgnore, obj.UpdatedAt}, args)
 			},
 		},
 		{
@@ -1181,8 +1203,8 @@ func (s *TableTestSuite) TestTable_InsertQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES ($, $, $, $);", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID, *obj.Name, obj.MaybeIgnore}, args)
+				s.Equal("INSERT INTO test_models (created_at, deleted_at, id, maybe_ignore, name, updated_at) VALUES ($, $, $, $, $, $);", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), any(nil), obj.ID, *obj.Name, obj.MaybeIgnore, obj.UpdatedAt}, args)
 			},
 		},
 		{
@@ -1202,8 +1224,8 @@ func (s *TableTestSuite) TestTable_InsertQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("INSERT INTO test_models (created_at, id, maybe_ignore, name) VALUES ($1, $2, $3, $4);", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), obj.ID, *obj.Name, obj.MaybeIgnore}, args)
+				s.Equal("INSERT INTO test_models (created_at, deleted_at, id, maybe_ignore, name, updated_at) VALUES ($1, $2, $3, $4, $5, $6);", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), any(nil), obj.ID, *obj.Name, obj.MaybeIgnore, obj.UpdatedAt}, args)
 			},
 		},
 	}
@@ -1271,7 +1293,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ?, T.name = ? WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.deleted_at = ?, T.maybe_ignore = ?, T.name = ?, T.updated_at = ? WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -1290,7 +1312,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ? WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ?, T.updated_at = ? WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -1310,7 +1332,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = $, T.maybe_ignore = $, T.name = $ WHERE 1=1 AND T.id = $;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = $, T.deleted_at = $, T.maybe_ignore = $, T.name = $, T.updated_at = $ WHERE 1=1 AND T.id = $;", query)
 			},
 		},
 		{
@@ -1330,7 +1352,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = $1, T.maybe_ignore = $2, T.name = $3 WHERE 1=1 AND T.id = $4;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = $1, T.deleted_at = $2, T.maybe_ignore = $3, T.name = $4, T.updated_at = $5 WHERE 1=1 AND T.id = $6;", query)
 			},
 		},
 		{
@@ -1350,7 +1372,7 @@ func (s *TableTestSuite) TestTable_UpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = :created_at, T.maybe_ignore = :maybe_ignore, T.name = :name WHERE 1=1 AND T.id = :id;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = :created_at, T.deleted_at = :deleted_at, T.maybe_ignore = :maybe_ignore, T.name = :name, T.updated_at = :updated_at WHERE 1=1 AND T.id = :id;", query)
 			},
 		},
 	}
@@ -1404,7 +1426,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ?, T.name = ? WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.deleted_at = ?, T.maybe_ignore = ?, T.name = ?, T.updated_at = ? WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -1423,7 +1445,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ? WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ?, T.updated_at = ? WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -1443,7 +1465,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = $, T.maybe_ignore = $, T.name = $ WHERE 1=1 AND T.id = $;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = $, T.deleted_at = $, T.maybe_ignore = $, T.name = $, T.updated_at = $ WHERE 1=1 AND T.id = $;", query)
 			},
 		},
 		{
@@ -1463,7 +1485,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = $1, T.maybe_ignore = $2, T.name = $3 WHERE 1=1 AND T.id = $4;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = $1, T.deleted_at = $2, T.maybe_ignore = $3, T.name = $4, T.updated_at = $5 WHERE 1=1 AND T.id = $6;", query)
 			},
 		},
 		{
@@ -1483,7 +1505,7 @@ func (s *TableTestSuite) TestTable_MustUpdateQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = :created_at, T.maybe_ignore = :maybe_ignore, T.name = :name WHERE 1=1 AND T.id = :id;", query)
+				s.Equal("UPDATE test_models AS T SET T.created_at = :created_at, T.deleted_at = :deleted_at, T.maybe_ignore = :maybe_ignore, T.name = :name, T.updated_at = :updated_at WHERE 1=1 AND T.id = :id;", query)
 			},
 		},
 	}
@@ -1532,8 +1554,8 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ?, T.name = ? WHERE 1=1 AND T.id = ?;", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), obj.MaybeIgnore, *obj.Name, obj.ID}, args)
+				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.deleted_at = ?, T.maybe_ignore = ?, T.name = ?, T.updated_at = ? WHERE 1=1 AND T.id = ?;", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), any(nil), obj.ID, *obj.Name, obj.MaybeIgnore, obj.UpdatedAt}, args)
 			},
 		},
 		{
@@ -1552,8 +1574,8 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ? WHERE 1=1 AND T.id = ?;", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), obj.MaybeIgnore, obj.ID}, args)
+				s.Equal("UPDATE test_models AS T SET T.created_at = ?, T.maybe_ignore = ?, T.updated_at = ? WHERE 1=1 AND T.id = ?;", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), obj.MaybeIgnore, obj.UpdatedAt, obj.ID}, args)
 			},
 		},
 		{
@@ -1573,8 +1595,8 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = $, T.maybe_ignore = $, T.name = $ WHERE 1=1 AND T.id = $;", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), obj.MaybeIgnore, *obj.Name, obj.ID}, args)
+				s.Equal("UPDATE test_models AS T SET T.created_at = $, T.deleted_at = $, T.maybe_ignore = $, T.name = $, T.updated_at = $ WHERE 1=1 AND T.id = $;", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), any(nil), *obj.Name, obj.MaybeIgnore, obj.UpdatedAt, obj.ID}, args)
 			},
 		},
 		{
@@ -1594,8 +1616,8 @@ func (s *TableTestSuite) TestTable_UpdateQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("UPDATE test_models AS T SET T.created_at = $1, T.maybe_ignore = $2, T.name = $3 WHERE 1=1 AND T.id = $4;", query)
-				s.ElementsMatch([]any{obj.CreatedAt(), obj.MaybeIgnore, *obj.Name, obj.ID}, args)
+				s.Equal("UPDATE test_models AS T SET T.created_at = $1, T.deleted_at = $2, T.maybe_ignore = $3, T.name = $4, T.updated_at = $5 WHERE 1=1 AND T.id = $6;", query)
+				s.ElementsMatch([]any{obj.CreatedAt(), any(nil), *obj.Name, obj.MaybeIgnore, obj.UpdatedAt, obj.ID}, args)
 			},
 		},
 	}
@@ -1988,7 +2010,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("SELECT T.created_at, T.deleted_at, T.id, T.maybe_ignore, T.name, T.updated_at FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -2008,7 +2030,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
+				s.Equal("SELECT T.created_at, T.deleted_at, T.id, T.maybe_ignore, T.name, T.updated_at FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
 			},
 		},
 		{
@@ -2028,7 +2050,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
+				s.Equal("SELECT T.created_at, T.deleted_at, T.id, T.maybe_ignore, T.name, T.updated_at FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
 			},
 		},
 		{
@@ -2048,7 +2070,7 @@ func (s *TableTestSuite) TestTable_SelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
+				s.Equal("SELECT T.created_at, T.deleted_at, T.id, T.maybe_ignore, T.name, T.updated_at FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
 			},
 		},
 	}
@@ -2102,7 +2124,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("SELECT T.created_at, T.deleted_at, T.id, T.maybe_ignore, T.name, T.updated_at FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
 			},
 		},
 		{
@@ -2122,7 +2144,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
+				s.Equal("SELECT T.created_at, T.deleted_at, T.id, T.maybe_ignore, T.name, T.updated_at FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
 			},
 		},
 		{
@@ -2142,7 +2164,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
+				s.Equal("SELECT T.created_at, T.deleted_at, T.id, T.maybe_ignore, T.name, T.updated_at FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
 			},
 		},
 		{
@@ -2162,7 +2184,7 @@ func (s *TableTestSuite) TestTable_MustSelectQuery() {
 			},
 			assertions: func(query string, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
+				s.Equal("SELECT T.created_at, T.deleted_at, T.id, T.maybe_ignore, T.name, T.updated_at FROM test_models AS T WHERE 1=1 AND T.id = :id;", query)
 			},
 		},
 	}
@@ -2211,7 +2233,7 @@ func (s *TableTestSuite) TestTable_SelectQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
+				s.Equal("SELECT T.created_at, T.deleted_at, T.id, T.maybe_ignore, T.name, T.updated_at FROM test_models AS T WHERE 1=1 AND T.id = ?;", query)
 				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},
@@ -2232,7 +2254,7 @@ func (s *TableTestSuite) TestTable_SelectQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
+				s.Equal("SELECT T.created_at, T.deleted_at, T.id, T.maybe_ignore, T.name, T.updated_at FROM test_models AS T WHERE 1=1 AND T.id = $;", query)
 				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},
@@ -2253,7 +2275,7 @@ func (s *TableTestSuite) TestTable_SelectQueryWithArgs() {
 			},
 			assertions: func(obj TestModel, query string, args []any, err error) {
 				s.Require().NoError(err)
-				s.Equal("SELECT T.created_at, T.id, T.maybe_ignore, T.name FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
+				s.Equal("SELECT T.created_at, T.deleted_at, T.id, T.maybe_ignore, T.name, T.updated_at FROM test_models AS T WHERE 1=1 AND T.id = $1;", query)
 				s.ElementsMatch([]any{obj.ID}, args)
 			},
 		},


### PR DESCRIPTION
**Description**

These changes add the appropriate support for struct fields that have a type of `time.Time` or `*time.Time`.

**Rationale**

Ultimately this was a bug - both of these types were explicitly supported for methods, but not struct fields.

**Suggested Version**

`v1.5.0`

**Example Usage**

```golang


package main

import (
	"fmt"
	"time"

	"github.com/freerware/morph"
)

type Starship struct {
	ID               string
	Name             string
	ManufacturedAt   time.Time
	DecommissionedAt *time.Time
	AccessCode       string `db:"-"`
}

func main() {
	s := Starship{
		ID:               "123",
		Name:             "Millennium Falcon",
		ManufacturedAt:   time.Now(),
		DecommissionedAt: nil,
		AccessCode:       "secret",
	}

	table := morph.Must(morph.Reflect(s, morph.WithTag("db"), morph.WithTableAlias("SHIP")))
	fmt.Println(table.InsertQuery()) // INSERT INTO starships (decommissioned_at, id, manufactured_at, name) VALUES (?, ?, ?, ?);
	fmt.Println(table.UpdateQuery()) // UPDATE starships AS SHIP SET SHIP.decommissioned_at = ?, SHIP.manufactured_at = ?, SHIP.name = ? WHERE 1=1 AND SHIP.id = ?;
	fmt.Println(table.DeleteQuery()) // DELETE FROM starships WHERE 1=1 AND id = ?;
	fmt.Println(table.SelectQuery()) // SELECT SHIP.decommissioned_at, SHIP.id, SHIP.manufactured_at, SHIP.name FROM starships AS SHIP WHERE 1=1 AND SHIP.id = ?;
	fmt.Println(table.Evaluate(s)) // map[decommissioned_at:<nil> id:123 manufactured_at:2025-05-17 22:27:21.917943 -0700 PDT m=+0.001372668 name:Millennium Falcon]
}
```
