### PR TITLE
Introduce support for evaluating `*time.Time` fields on structs.

### DIFF
--- a/table.go
+++ b/table.go
@@ -243,7 +243,6 @@ func (t *Table) Evaluate(obj any) (EvaluationResult, error) {
 			}
 
 			if val.Kind() == reflect.Ptr && !val.IsZero() {
-				fmt.Println(fmt.Sprintf("%v: %v", fieldName, val.Type()))
 				if val.Elem().Kind() == reflect.Struct && val.Elem().Type() != reflect.TypeOf(time.Time{}) {
 					continue
 				}

--- a/table.go
+++ b/table.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+	"time"
 )
 
 // Defines the various errors that can occur when interacting with tables.
@@ -242,7 +243,8 @@ func (t *Table) Evaluate(obj any) (EvaluationResult, error) {
 			}
 
 			if val.Kind() == reflect.Ptr && !val.IsZero() {
-				if val.Elem().Kind() == reflect.Struct {
+				fmt.Println(fmt.Sprintf("%v: %v", fieldName, val.Type()))
+				if val.Elem().Kind() == reflect.Struct && val.Elem().Type() != reflect.TypeOf(time.Time{}) {
 					continue
 				}
 				val = val.Elem()

--- a/table_test.go
+++ b/table_test.go
@@ -324,6 +324,8 @@ func (s *TableTestSuite) TestTable_AddColumns() {
 }
 
 func (s *TableTestSuite) TestTable_EvaluateWithValue() {
+	deleted_at := time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local)
+
 	tests := []struct {
 		name           string
 		reflectOptions []morph.ReflectOption
@@ -343,6 +345,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 						Title:       "another",
 						Description: nil,
 					},
+					DeletedAt: &deleted_at,
 				}
 			},
 			assertions: func(result morph.EvaluationResult, err error) {
@@ -352,7 +355,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 						"id":           1,
 						"name":         "test",
 						"maybe_ignore": false,
-						"deleted_at":   nil,
+						"deleted_at":   deleted_at,
 						"updated_at":   time.Time{},
 						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
@@ -373,6 +376,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 						Title:       "another",
 						Description: nil,
 					},
+					DeletedAt: &deleted_at,
 				}
 			},
 			assertions: func(result morph.EvaluationResult, err error) {
@@ -381,7 +385,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 					morph.EvaluationResult{
 						"identifier": 1,
 						"name":       "test",
-						"deleted_at": nil,
+						"deleted_at": deleted_at,
 						"updated_at": time.Time{},
 						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
@@ -401,6 +405,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 						Title:       "another",
 						Description: nil,
 					},
+					DeletedAt: nil,
 				}
 			},
 			assertions: func(result morph.EvaluationResult, err error) {
@@ -441,6 +446,8 @@ func (s *TableTestSuite) TestTable_EvaluateWithValue() {
 }
 
 func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
+	deletedAt := time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local)
+
 	tests := []struct {
 		name           string
 		reflectOptions []morph.ReflectOption
@@ -460,6 +467,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 						Title:       "another",
 						Description: nil,
 					},
+					DeletedAt: &deletedAt,
 				}
 			},
 			assertions: func(result morph.EvaluationResult, err error) {
@@ -469,7 +477,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 						"id":           1,
 						"name":         "test",
 						"maybe_ignore": false,
-						"deleted_at":   nil,
+						"deleted_at":   deletedAt,
 						"updated_at":   time.Time{},
 						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
@@ -490,6 +498,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 						Title:       "another",
 						Description: nil,
 					},
+					DeletedAt: &deletedAt,
 				}
 			},
 			assertions: func(result morph.EvaluationResult, err error) {
@@ -498,7 +507,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 					morph.EvaluationResult{
 						"identifier": 1,
 						"name":       "test",
-						"deleted_at": nil,
+						"deleted_at": deletedAt,
 						"updated_at": time.Time{},
 						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
@@ -518,6 +527,7 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 						Title:       "another",
 						Description: nil,
 					},
+					DeletedAt: nil,
 				}
 			},
 			assertions: func(result morph.EvaluationResult, err error) {
@@ -558,6 +568,8 @@ func (s *TableTestSuite) TestTable_EvaluateWithPointer() {
 }
 
 func (s *TableTestSuite) TestTable_EvaluateMismatched() {
+	deletedAt := time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local)
+
 	tests := []struct {
 		name           string
 		reflectOptions []morph.ReflectOption
@@ -577,6 +589,7 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 						Title:       "another",
 						Description: nil,
 					},
+					DeletedAt: &deletedAt,
 				}
 			},
 			assertions: func(result morph.EvaluationResult, err error) {
@@ -586,7 +599,7 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 						"id":           1,
 						"name":         "test",
 						"maybe_ignore": false,
-						"deleted_at":   nil,
+						"deleted_at":   deletedAt,
 						"updated_at":   time.Time{},
 						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
@@ -607,6 +620,7 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 						Title:       "another",
 						Description: nil,
 					},
+					DeletedAt: &deletedAt,
 				}
 			},
 			assertions: func(result morph.EvaluationResult, err error) {
@@ -615,7 +629,7 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 					morph.EvaluationResult{
 						"identifier": 1,
 						"name":       "test",
-						"deleted_at": nil,
+						"deleted_at": deletedAt,
 						"updated_at": time.Time{},
 						"created_at": time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
@@ -635,6 +649,7 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 						Title:       "another",
 						Description: nil,
 					},
+					DeletedAt: nil,
 				}
 			},
 			assertions: func(result morph.EvaluationResult, err error) {
@@ -675,6 +690,8 @@ func (s *TableTestSuite) TestTable_EvaluateMismatched() {
 }
 
 func (s *TableTestSuite) TestTable_MustEvaluateValue() {
+	deletedAt := time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local)
+
 	tests := []struct {
 		name           string
 		reflectOptions []morph.ReflectOption
@@ -701,6 +718,7 @@ func (s *TableTestSuite) TestTable_MustEvaluateValue() {
 						Title:       "another",
 						Description: nil,
 					},
+					DeletedAt: &deletedAt,
 				}
 			},
 			assertions: func(result morph.EvaluationResult) {
@@ -709,7 +727,7 @@ func (s *TableTestSuite) TestTable_MustEvaluateValue() {
 						"id":           1,
 						"name":         "test",
 						"maybe_ignore": false,
-						"deleted_at":   nil,
+						"deleted_at":   deletedAt,
 						"updated_at":   time.Time{},
 						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},
@@ -745,6 +763,8 @@ func (s *TableTestSuite) TestTable_MustEvaluateValue() {
 	}
 }
 func (s *TableTestSuite) TestTable_MustEvaluatePointer() {
+	deletedAt := time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local)
+
 	tests := []struct {
 		name           string
 		reflectOptions []morph.ReflectOption
@@ -771,6 +791,7 @@ func (s *TableTestSuite) TestTable_MustEvaluatePointer() {
 						Title:       "another",
 						Description: nil,
 					},
+					DeletedAt: &deletedAt,
 				}
 			},
 			assertions: func(result morph.EvaluationResult) {
@@ -779,7 +800,7 @@ func (s *TableTestSuite) TestTable_MustEvaluatePointer() {
 						"id":           1,
 						"name":         "test",
 						"maybe_ignore": false,
-						"deleted_at":   nil,
+						"deleted_at":   deletedAt,
 						"updated_at":   time.Time{},
 						"created_at":   time.Date(2024, time.February, 28, 10, 30, 0, 0, time.Local),
 					},


### PR DESCRIPTION
**Description**

In #19, support was added for constructing tables that included mappings to struct fields with times of `time.Time` and `*time.Time`. However, what was missed is supporting the _evaluation_ of these types (specifically `*time.Time` was not supported). These changes fix that issue.

**Rationale**

This was a bug - the intention is to support evaluation of `*time.Time` fields correctly.

**Suggested Version**

`v1.6.0`

**Example Usage**

```go
package main

import (
	"fmt"
	"time"

	"github.com/freerware/morph"
)

type Starship struct {
	ID               string
	Name             string
	ManufacturedAt   time.Time
	DecommissionedAt *time.Time
	AccessCode       string `db:"-"`
}

func main() {
	decommissionedAt := time.Now()

	s := Starship{
		ID:               "123",
		Name:             "Millennium Falcon",
		ManufacturedAt:   time.Now(),
		DecommissionedAt: &decommissionedAt,
		AccessCode:       "secret",
	}

	table := morph.Must(morph.Reflect(s, morph.WithTag("db"), morph.WithTableAlias("SHIP")))
	fmt.Println(table.InsertQuery())
	fmt.Println(table.UpdateQuery())
	fmt.Println(table.DeleteQuery())
	fmt.Println(table.SelectQuery())
	fmt.Println(table.Evaluate(s))

        // INSERT INTO starships (decommissioned_at, id, manufactured_at, name) VALUES (?, ?, ?, ?); <nil>
        // UPDATE starships AS SHIP SET SHIP.decommissioned_at = ?, SHIP.manufactured_at = ?, SHIP.name = ? WHERE 1=1 AND SHIP.id = ?; <nil>
        // DELETE FROM starships WHERE 1=1 AND id = ?; <nil>
        // SELECT SHIP.decommissioned_at, SHIP.id, SHIP.manufactured_at, SHIP.name FROM starships AS SHIP WHERE 1=1 AND SHIP.id = ?; <nil>
        // map[decommissioned_at:2025-05-24 21:53:27.037755 -0700 PDT m=+0.000515085 id:123 manufactured_at:2025-05-24 21:53:27.037756 -0700 PDT m=+0.000515168 name:Millennium Falcon] <nil>
}
```